### PR TITLE
Adjust the Installing section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,12 @@ Contributions are welcome, but please make an issue first before writing any cod
 Penumbra has support for most TexTools modpacks however this is provided on a best-effort basis and support is not guaranteed. Built in tooling will be added to Penumbra over time to avoid many common TexTools use cases.
 
 ## Installing 
-While this project is still a work in progress, you can use it by including the below custom repository URL in the custom plugin repository list in XIVLauncher. Please don't install it manually in case there is a bug to be fixed in future versions and you won't get updates automatically.
+While this project is still a work in progress, you can use it by addin the following URL to the custom plugin repositories list in your Dalamud settings
+1. `/xlsettings` -> Experimental tab
+2. Copy and paste the repo.json link below
+3. Click on the + button
+4. Click on the "Save and Close" button
+5. You will now see Penumbra listed in the Dalamud Plugin Installer
+
+Please do not install Penumbra manually by downloading a release zip and unpacking it into your devPlugins folder. That will require manually updating Penumbra and you will miss out on features and bug fixes as you won't get update notifications automatically. Any manually installed copies of Penumbra should be removed before switching to the custom plugin respository method, as they will conflict.
 - https://raw.githubusercontent.com/xivdev/Penumbra/master/repo.json


### PR DESCRIPTION
While a bit more hand-holdy, this should cut down on the number of people asking how to add the custom repo URL and dissuade people from thing to manually install the plugin as there are multiple users who were getting confused by the prior terminology used. (Like making assumptions that adding the URL was all they needed to do)