### PR TITLE
Add redraw route to http api

### DIFF
--- a/Penumbra/Api/RedrawController.cs
+++ b/Penumbra/Api/RedrawController.cs
@@ -1,0 +1,35 @@
+using System.Threading.Tasks;
+using EmbedIO;
+using EmbedIO.Routing;
+using EmbedIO.WebApi;
+using Penumbra.GameData.Enums;
+
+namespace Penumbra.Api
+{
+    public class RedrawController : WebApiController
+    {
+        private readonly Penumbra _penumbra;
+
+        public RedrawController( Penumbra penumbra )
+            => _penumbra = penumbra;
+
+        [Route( HttpVerbs.Post, "/redraw" )]
+        public async Task Redraw()
+        {
+            RedrawData data = await HttpContext.GetRequestDataAsync<RedrawData>();
+            _penumbra.Api.RedrawObject( data.Name, data.Type );
+        }
+
+        [Route( HttpVerbs.Post, "/redrawAll" )]
+        public void RedrawAll()
+        {
+            _penumbra.Api.RedrawAll(RedrawType.WithoutSettings);
+        }
+
+        public class RedrawData
+        {
+            public string Name { get; set; } = string.Empty;
+            public RedrawType Type { get; set; } = RedrawType.WithSettings;
+        }
+    }
+}

--- a/Penumbra/Penumbra.cs
+++ b/Penumbra/Penumbra.cs
@@ -166,7 +166,8 @@ public class Penumbra : IDalamudPlugin
                .WithMode( HttpListenerMode.EmbedIO ) )
            .WithCors( prefix )
            .WithWebApi( "/api", m => m
-               .WithController( () => new ModsController( this ) ) );
+               .WithController( () => new ModsController( this ) )
+               .WithController( () => new RedrawController( this ) ) );
 
         _webServer.StateChanged += ( _, e ) => PluginLog.Information( $"WebServer New State - {e.NewState}" );
 


### PR DESCRIPTION
This change adds a "/redraw" route to the http api to allow external applications ([Anamnesis](https://github.com/imchillin/Anamnesis/commit/a8cf3582ac77ce285024b2a489949d817dd36ac4)) to trigger actor redraws