### PR TITLE
Collections API / Redraw with collection method

### DIFF
--- a/Penumbra/Api/CollectionsController.cs
+++ b/Penumbra/Api/CollectionsController.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dalamud.Logging;
+using EmbedIO;
+using EmbedIO.Routing;
+using EmbedIO.WebApi;
+using Penumbra.GameData.Enums;
+using Penumbra.Mods;
+using Penumbra.Util;
+
+namespace Penumbra.Api
+{
+    public class CollectionsController : WebApiController
+    {
+        [Route( HttpVerbs.Get, "/collections" )]
+        public object? GetCollections()
+        {
+            var collectionsManager = Service<ModManager>.Get().Collections;
+
+            List<string> collections = new List<string>();
+            foreach( (string name, ModCollection collection) in collectionsManager.Collections )
+            {
+                collections.Add( name );
+            }
+
+            return collections;
+        }
+
+        [Route( HttpVerbs.Get, "/collections/{name}" )]
+        public object? GetCollection(string name)
+        {
+            var collectionsManager = Service<ModManager>.Get().Collections;
+
+            if( collectionsManager.Collections.TryGetValue( name, out var collection ) )
+                return collection;
+
+            return null;
+        }
+    }
+}

--- a/Penumbra/Api/PenumbraApi.cs
+++ b/Penumbra/Api/PenumbraApi.cs
@@ -66,6 +66,21 @@ namespace Penumbra.Api
             _penumbra!.ObjectReloader.RedrawObject( name, setting );
         }
 
+        public void RedrawObject( string name, string collection )
+        {
+            CheckInitialized();
+
+            var modManager = Service<ModManager>.Get();
+
+            if( modManager.Collections.Collections.TryGetValue( collection, out var characterCollection ) )
+            {
+                modManager.Collections.SetActiveCollection( characterCollection, name );
+
+                RedrawType setting = RedrawType.WithoutSettings;
+                _penumbra!.ObjectReloader.RedrawObject( name, setting );
+            }
+        }
+
         public void RedrawObject( GameObject? gameObject, RedrawType setting )
         {
             CheckInitialized();

--- a/Penumbra/Api/RedrawController.cs
+++ b/Penumbra/Api/RedrawController.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Dalamud.Logging;
 using EmbedIO;
 using EmbedIO.Routing;
 using EmbedIO.WebApi;
@@ -17,7 +18,15 @@ namespace Penumbra.Api
         public async Task Redraw()
         {
             RedrawData data = await HttpContext.GetRequestDataAsync<RedrawData>();
-            _penumbra.Api.RedrawObject( data.Name, data.Type );
+
+            if( data.CharacterCollection == null )
+            {
+                _penumbra.Api.RedrawObject( data.Name, data.Type );
+            }
+            else
+            {
+                _penumbra.Api.RedrawObject( data.Name, data.CharacterCollection );
+            }
         }
 
         [Route( HttpVerbs.Post, "/redrawAll" )]
@@ -30,6 +39,7 @@ namespace Penumbra.Api
         {
             public string Name { get; set; } = string.Empty;
             public RedrawType Type { get; set; } = RedrawType.WithSettings;
+            public string? CharacterCollection { get; set; } = string.Empty;
         }
     }
 }

--- a/Penumbra/Penumbra.cs
+++ b/Penumbra/Penumbra.cs
@@ -167,7 +167,8 @@ public class Penumbra : IDalamudPlugin
            .WithCors( prefix )
            .WithWebApi( "/api", m => m
                .WithController( () => new ModsController( this ) )
-               .WithController( () => new RedrawController( this ) ) );
+               .WithController( () => new RedrawController( this ) )
+               .WithController( () => new CollectionsController() ) );
 
         _webServer.StateChanged += ( _, e ) => PluginLog.Information( $"WebServer New State - {e.NewState}" );
 


### PR DESCRIPTION
This change introduces a http route `/api/collections` to get a list of all the character collections, and adds a collection name parameter to the redraw route to allow external applications (Anamnesis) to redraw an actor with a specific collection, overriding the default penumbra behavior.