### PR TITLE
PluginLog inside OnFrameworkUpdate

### DIFF
--- a/Penumbra.PlayerWatch/PlayerWatchBase.cs
+++ b/Penumbra.PlayerWatch/PlayerWatchBase.cs
@@ -301,7 +301,11 @@ internal class PlayerWatchBase : IDisposable
 
             var id = GetId( character );
             SeenActors.Add( id );
+
+#if DEBUG
             PluginLog.Verbose( "Comparing Gear for {PlayerName:l} ({Id}) at 0x{Address:X}...", character.Name, id, character.Address.ToInt64() );
+#endif
+
             if( !watch.FoundActors.TryGetValue( id, out var equip ) )
             {
                 equip                   = new CharacterEquipment( character );


### PR DESCRIPTION
I use /xllog a lot with verbose enabled, and when I'm using Glamourer's Fixed Designs this line goes really wild for being inside OnFrameworkUpdate, so I thought it would be nice to have it only when debugging. 