### PR TITLE
Add descriptions for SubMods

### DIFF
--- a/Penumbra/Import/TexToolsImporter.ModPack.cs
+++ b/Penumbra/Import/TexToolsImporter.ModPack.cs
@@ -173,7 +173,6 @@ public partial class TexToolsImporter
                 {
                     var name           = numGroups == 1 ? _currentGroupName : $"{_currentGroupName}, Part {groupId + 1}";
                     options.Clear();
-                    var description = new StringBuilder();
                     var groupFolder = Mod.NewSubFolderName( _currentModDirectory, name )
                      ?? new DirectoryInfo( Path.Combine( _currentModDirectory.FullName,
                             numGroups == 1 ? $"Group {groupPriority + 1}" : $"Group {groupPriority + 1}, Part {groupId + 1}" ) );
@@ -188,12 +187,6 @@ public partial class TexToolsImporter
                          ?? new DirectoryInfo( Path.Combine( groupFolder.FullName, $"Option {i + optionIdx + 1}" ) );
                         ExtractSimpleModList( optionFolder, option.ModsJsons );
                         options.Add( Mod.CreateSubMod( _currentModDirectory, optionFolder, option ) );
-                        description.Append( option.Description );
-                        if( !string.IsNullOrEmpty( option.Description ) )
-                        {
-                            description.Append( '\n' );
-                        }
-
                         if( option.IsChecked )
                         {
                             defaultSettings = group.SelectionType == GroupType.Multi
@@ -220,7 +213,7 @@ public partial class TexToolsImporter
                     }
 
                     Mod.CreateOptionGroup( _currentModDirectory, group.SelectionType, name, groupPriority, groupPriority,
-                        defaultSettings ?? 0, description.ToString(), options );
+                        defaultSettings ?? 0, string.Empty, options );
                     ++groupPriority;
                 }
             }

--- a/Penumbra/Mods/Manager/Mod.Manager.Options.cs
+++ b/Penumbra/Mods/Manager/Mod.Manager.Options.cs
@@ -124,6 +124,23 @@ public sealed partial class Mod
             ModOptionChanged.Invoke( ModOptionChangeType.DisplayChange, mod, groupIdx, -1, -1 );
         }
 
+        public void ChangeOptionDescription( Mod mod, int groupIdx, int optionIdx, string newDescription )
+        {
+            var group  = mod._groups[ groupIdx ];
+            var option = group[ optionIdx ];
+            if( option.Description == newDescription )
+            {
+                return;
+            }
+
+            var _ = option switch
+            {
+                SubMod s => s.Description = newDescription,
+            };
+
+            ModOptionChanged.Invoke( ModOptionChangeType.DisplayChange, mod, groupIdx, optionIdx, -1 );
+        }
+
         public void ChangeGroupPriority( Mod mod, int groupIdx, int newPriority )
         {
             var group = mod._groups[ groupIdx ];

--- a/Penumbra/Mods/Mod.Creation.cs
+++ b/Penumbra/Mods/Mod.Creation.cs
@@ -116,6 +116,7 @@ public partial class Mod
         var mod = new SubMod( null! ) // Mod is irrelevant here, only used for saving.
         {
             Name = option.Name,
+            Description = option.Description,
         };
         foreach( var (_, gamePath, file) in list )
         {

--- a/Penumbra/Mods/Subclasses/ISubMod.cs
+++ b/Penumbra/Mods/Subclasses/ISubMod.cs
@@ -10,6 +10,7 @@ public interface ISubMod
 {
     public string Name { get; }
     public string FullName { get; }
+    public string Description { get; }
 
     public IReadOnlyDictionary< Utf8GamePath, FullPath > Files { get; }
     public IReadOnlyDictionary< Utf8GamePath, FullPath > FileSwaps { get; }
@@ -22,6 +23,8 @@ public interface ISubMod
         j.WriteStartObject();
         j.WritePropertyName( nameof( Name ) );
         j.WriteValue( mod.Name );
+        j.WritePropertyName( nameof(Description) );
+        j.WriteValue( mod.Description );
         if( priority != null )
         {
             j.WritePropertyName( nameof( IModGroup.Priority ) );

--- a/Penumbra/Mods/Subclasses/Mod.Files.SubMod.cs
+++ b/Penumbra/Mods/Subclasses/Mod.Files.SubMod.cs
@@ -107,6 +107,8 @@ public partial class Mod
         public string FullName
             => GroupIdx < 0 ? "Default Option" : $"{ParentMod.Groups[ GroupIdx ].Name}: {Name}";
 
+        public string Description { get; set; } = string.Empty;
+
         internal IMod ParentMod { get; private init; }
         internal int GroupIdx { get; private set; }
         internal int OptionIdx { get; private set; }
@@ -143,8 +145,9 @@ public partial class Mod
             ManipulationData.Clear();
 
             // Every option has a name, but priorities are only relevant for multi group options.
-            Name     = json[ nameof( ISubMod.Name ) ]?.ToObject< string >()    ?? string.Empty;
-            priority = json[ nameof( IModGroup.Priority ) ]?.ToObject< int >() ?? 0;
+            Name        = json[ nameof( ISubMod.Name ) ]?.ToObject< string >()        ?? string.Empty;
+            Description = json[ nameof( ISubMod.Description ) ]?.ToObject< string >() ?? string.Empty;
+            priority    = json[ nameof( IModGroup.Priority ) ]?.ToObject< int >()     ?? 0;
 
             var files = ( JObject? )json[ nameof( Files ) ];
             if( files != null )

--- a/Penumbra/UI/ConfigWindow.ModPanel.Settings.cs
+++ b/Penumbra/UI/ConfigWindow.ModPanel.Settings.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Numerics;
 using Dalamud.Interface;
+using Dalamud.Interface.Components;
 using ImGuiNET;
 using OtterGui;
 using OtterGui.Classes;
@@ -179,6 +180,12 @@ public partial class ConfigWindow
                         Penumbra.CollectionManager.Current.SetModSetting( _mod.Index, groupIdx, ( uint )idx2 );
                     }
 
+                    if( !string.IsNullOrEmpty( group[ idx2 ].Description ) )
+                    {
+                        ImGui.SameLine();
+                        ImGuiComponents.HelpMarker(group[idx2].Description);
+                    }
+
                     id.Pop();
                 }
             }
@@ -211,6 +218,12 @@ public partial class ConfigWindow
                 {
                     flags = setting ? flags | flag : flags & ~flag;
                     Penumbra.CollectionManager.Current.SetModSetting( _mod.Index, groupIdx, flags );
+                }
+
+                if( !string.IsNullOrEmpty( group[ idx2 ].Description ) )
+                {
+                    ImGui.SameLine();
+                    ImGuiComponents.HelpMarker(group[idx2].Description);
                 }
 
                 id.Pop();


### PR DESCRIPTION
Also adjusted importing of TexTools mods to give each option its own description instead of combining all option descriptions into the group description.

![image](https://user-images.githubusercontent.com/11886749/216754127-49f713b4-15c9-489f-83ec-2aabd5e55fbe.png)
