### PR TITLE
Fix double `by` in mod name display

### DIFF
--- a/Penumbra/UI/ConfigWindow.ModPanel.Header.cs
+++ b/Penumbra/UI/ConfigWindow.ModPanel.Header.cs
@@ -176,7 +176,7 @@ public partial class ConfigWindow
             }
 
             // Author
-            var author = _mod.Author.IsEmpty ? string.Empty : $"by  {_mod.Author}";
+            var author = _mod.Author.IsEmpty ? string.Empty : $"{_mod.Author}";
             if( author != _modAuthor )
             {
                 _modAuthor      = author;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11886749/231005493-35bdeb9d-47cd-44fb-81e6-c51b7da70502.png)
