### PR TITLE
Ignore hidden files when generating the unused files list.

### DIFF
--- a/Penumbra/Mods/Mod.Files.cs
+++ b/Penumbra/Mods/Mod.Files.cs
@@ -65,6 +65,7 @@ public partial class Mod
         var modFiles = AllFiles.ToHashSet();
         return ModPath.EnumerateDirectories()
            .SelectMany( f => f.EnumerateFiles( "*", SearchOption.AllDirectories ) )
+           .Where( f => !f.Attributes.HasFlag( FileAttributes.Hidden ) )
            .Select( f => new FullPath( f ) )
            .Where( f => !modFiles.Contains( f ) )
            .ToList();


### PR DESCRIPTION
Don't include hidden files in the unused file list for a mod. These files are typically things such as .git or otherwise intended to be hidden and shouldn't be included as part of the list of files which could be used.