### PR TITLE
Image Preview

### DIFF
--- a/Penumbra/Configuration.cs
+++ b/Penumbra/Configuration.cs
@@ -85,6 +85,9 @@ public class Configuration : IPluginConfiguration, ISavable
     public bool   KeepDefaultMetaChanges  { get; set; } = false;
     public string DefaultModAuthor        { get; set; } = DefaultTexToolsData.Author;
 
+    public bool   ShowPreviewImages         { get; set; } = true;
+    public bool   ImportPreviewImages       { get; set; } = true;
+
     public Dictionary<ColorId, uint> Colors { get; set; }
         = Enum.GetValues<ColorId>().ToDictionary(c => c, c => c.Data().DefaultColor);
 

--- a/Penumbra/Import/TexToolsImporter.Archives.cs
+++ b/Penumbra/Import/TexToolsImporter.Archives.cs
@@ -65,6 +65,12 @@ public partial class TexToolsImporter
                 continue;
             }
 
+            if (!string.IsNullOrEmpty(reader.Entry.Key) && reader.Entry.Key.StartsWith("images") && !_config.ImportPreviewImages)
+            {
+                // Skip extracting the "images" folder if ImportPreviewImages is false
+                continue;
+            }
+
             Penumbra.Log.Information($"        -> Extracting {reader.Entry.Key}");
             // Check that the mod has a valid name in the meta.json file.
             if (Path.GetFileName(reader.Entry.Key) == "meta.json")

--- a/Penumbra/Mods/Mod.cs
+++ b/Penumbra/Mods/Mod.cs
@@ -53,6 +53,8 @@ public sealed class Mod : IMod
     public string                Note       { get; internal set; } = string.Empty;
     public bool                  Favorite   { get; internal set; } = false;
 
+    // Preview Images
+    public List<string> PreviewImagePaths = new List<string>();
 
     // Options
     public readonly SubMod          Default;

--- a/Penumbra/Mods/ModCreator.cs
+++ b/Penumbra/Mods/ModCreator.cs
@@ -69,6 +69,7 @@ public partial class ModCreator(SaveService _saveService, Configuration config, 
             return false;
 
         _dataEditor.LoadLocalData(mod);
+        LoadPreviewImages(mod);
         LoadDefaultOption(mod);
         LoadAllGroups(mod);
         if (incorporateMetaChanges)
@@ -460,5 +461,26 @@ public partial class ModCreator(SaveService _saveService, Configuration config, 
         }
 
         return null;
+    }
+
+    // <summary> Enumerate preview image files for the mod and update PreviewImagePaths
+    public bool LoadPreviewImages(Mod mod)
+    {
+        string[] extensions = { ".png", ".jpg" };
+        DirectoryInfo imagesDirectory = new DirectoryInfo(Path.Combine(mod.ModPath.FullName, "images"));
+
+        try
+        {
+            mod.PreviewImagePaths = imagesDirectory.GetFiles()
+                                      .Where(file => extensions.Contains(file.Extension.ToLower()))
+                                      .Select(file => file.FullName)
+                                      .ToList();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Penumbra.Log.Error($"Error, unable to enumerate mod preview image paths for mod {mod.Name} \n Exception: {ex.Message}");
+            return false;
+        }
     }
 }

--- a/Penumbra/Penumbra.cs
+++ b/Penumbra/Penumbra.cs
@@ -22,6 +22,7 @@ using Penumbra.GameData.Enums;
 using Penumbra.Interop.Structs;
 using Penumbra.UI;
 using ResidentResourceManager = Penumbra.Interop.Services.ResidentResourceManager;
+using Penumbra.Mods;
 
 namespace Penumbra;
 

--- a/Penumbra/UI/ModsTab/ModFileSystemSelector.cs
+++ b/Penumbra/UI/ModsTab/ModFileSystemSelector.cs
@@ -277,10 +277,19 @@ public sealed class ModFileSystemSelector : FileSystemSelector<Mod, ModFileSyste
     private void AddImportModButton(Vector2 size)
     {
         var button = ImGuiUtil.DrawDisabledButton(FontAwesomeIcon.FileImport.ToIconString(), size,
-            "Import one or multiple mods from Tex Tools Mod Pack Files or Penumbra Mod Pack Files.", !_modManager.Valid, true);
+            "Import one or multiple mods from Tex Tools Mod Pack Files or Penumbra Mod Pack Files.\nHold control while clicking to skip importing preview images from selected mods.", !_modManager.Valid, true);
         _tutorial.OpenTutorial(BasicTutorialSteps.ModImport);
         if (!button)
             return;
+
+        if (ImGui.GetIO().KeyCtrl)
+        {
+            _config.ImportPreviewImages = false;
+        } 
+        else
+        {
+            _config.ImportPreviewImages = true;
+        }
 
         var modPath = _config.DefaultModImportPath.Length > 0
             ? _config.DefaultModImportPath
@@ -293,7 +302,6 @@ public sealed class ModFileSystemSelector : FileSystemSelector<Mod, ModFileSyste
             {
                 if (!s)
                     return;
-
                 _modImportManager.AddUnpack(f);
             }, 0, modPath, _config.AlwaysOpenDefaultImport);
     }

--- a/Penumbra/UI/ModsTab/ModPanelDescriptionTab.cs
+++ b/Penumbra/UI/ModsTab/ModPanelDescriptionTab.cs
@@ -4,6 +4,17 @@ using OtterGui.Raii;
 using OtterGui;
 using OtterGui.Widgets;
 using Penumbra.Mods.Manager;
+using ImGuiScene;
+using System.Collections.Generic;
+using System.Numerics;
+using System.IO;
+using System.Threading.Tasks;
+using Dalamud.Plugin;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Formats.Png;
+using Penumbra.Mods;
+using Dalamud.Interface.Internal;
 
 namespace Penumbra.UI.ModsTab;
 
@@ -14,12 +25,19 @@ public class ModPanelDescriptionTab : ITab
     private readonly ModManager            _modManager;
     private readonly TagButtons            _localTags = new();
     private readonly TagButtons            _modTags   = new();
+    private readonly Configuration _config;
+    private DalamudPluginInterface _pi;
+    private int _currentImageIndex = 0;
+    private Task<IDalamudTextureWrap>? _currentImageTexture;
 
-    public ModPanelDescriptionTab(ModFileSystemSelector selector, TutorialService tutorial, ModManager modManager)
+    public ModPanelDescriptionTab(ModFileSystemSelector selector, TutorialService tutorial, ModManager modManager, Configuration config, DalamudPluginInterface pi)
     {
-        _selector   = selector;
-        _tutorial   = tutorial;
+        _selector = selector;
+        _tutorial = tutorial;
         _modManager = modManager;
+        _config = config;
+        _pi = pi;
+        _selector.SelectionChanged += OnSelectionChange;
     }
 
     public ReadOnlySpan<byte> Label
@@ -36,7 +54,7 @@ public class ModPanelDescriptionTab : ITab
         ImGui.Dummy(ImGuiHelpers.ScaledVector2(2));
         var tagIdx = _localTags.Draw("Local Tags: ",
             "Custom tags you can set personally that will not be exported to the mod data but only set for you.\n"
-          + "If the mod already contains a local tag in its own tags, the local tag will be ignored.", _selector.Selected!.LocalTags,
+            + "If the mod already contains a local tag in its own tags, the local tag will be ignored.", _selector.Selected!.LocalTags,
             out var editedTag);
         _tutorial.OpenTutorial(BasicTutorialSteps.Tags);
         if (tagIdx >= 0)
@@ -48,8 +66,133 @@ public class ModPanelDescriptionTab : ITab
                 ImGui.CalcTextSize("Local ").X - ImGui.CalcTextSize("Mod ").X);
 
         ImGui.Dummy(ImGuiHelpers.ScaledVector2(2));
+
+        if (_config.ShowPreviewImages == true && _selector.Selected!.PreviewImagePaths.Count > 0)
+        {
+            ImGui.Separator();
+
+            List<string> previewImagePaths = _selector.Selected!.PreviewImagePaths;
+
+            if (_currentImageTexture == null)
+            {
+                // Check if the current image index is within bounds
+                if (_currentImageIndex < 0 || _currentImageIndex >= previewImagePaths.Count)
+                {
+                    _currentImageIndex = 0; // Reset to the first image if out of bounds
+                }
+
+                // Start loading the image texture asynchronously
+                _currentImageTexture = LoadImageTextureAsync(previewImagePaths[_currentImageIndex]);
+            }
+            else if (_currentImageTexture.IsCompleted)
+            {
+                // Get the loaded image texture
+                IDalamudTextureWrap imageTexture = _currentImageTexture.Result;
+
+                // Display the image texture
+                if (imageTexture != null)
+                {
+                    ImGui.Image(imageTexture.ImGuiHandle, new Vector2(imageTexture.Width, imageTexture.Height));
+                    int imageWidth = imageTexture.Width;
+                    Vector2 cursorPos = ImGui.GetCursorPos();
+
+                    // Calculate the available width for the navigation buttons
+                    float buttonWidth = ImGui.CalcTextSize(">").X + 2 * ImGui.GetStyle().ItemSpacing.X;
+
+                    // Calculate the remaining width for the counter and file name label
+                    float remainingWidth = imageTexture?.Width - 2 * buttonWidth ?? 0;
+
+                    // Anchor the left button under the bottom left side of the image
+                    ImGui.SetCursorPos(new Vector2(cursorPos.X, cursorPos.Y));
+                    if (ImGui.ArrowButton("##PrevImage", ImGuiDir.Left))
+                    {
+                        // Navigate to the previous image
+                        _currentImageIndex = (_currentImageIndex - 1 + previewImagePaths.Count) % previewImagePaths.Count;
+
+                        // Reset the current image texture to load the new image
+                        _currentImageTexture = null;
+                    }
+
+                    // Anchor the right button under the bottom right side of the image
+                    ImGui.SetCursorPos(new Vector2(cursorPos.X + imageWidth - buttonWidth, cursorPos.Y));
+                    if (ImGui.ArrowButton("##NextImage", ImGuiDir.Right))
+                    {
+                        // Navigate to the next image
+                        _currentImageIndex = (_currentImageIndex + 1) % previewImagePaths.Count;
+                        // Reset the current image texture to load the new image
+                        _currentImageTexture = null;
+                    }
+
+                    // Calculate the width for the counter label
+                    string counterLabel = $"{_currentImageIndex + 1} / {previewImagePaths.Count}";
+                    float counterWidth = ImGui.CalcTextSize(counterLabel).X;
+
+                    // Calculate the width and height for the file name label
+                    string fileName = Path.GetFileNameWithoutExtension(previewImagePaths[_currentImageIndex]);
+                    Vector2 fileNameSize = ImGui.CalcTextSize(fileName);
+
+                    // Calculate the offset for centering the labels
+                    float offset = (remainingWidth - counterWidth) * 0.5f;
+                    float nameOffset = (remainingWidth - fileNameSize.X) * 0.5f;
+
+                    // Calculate the vertical offset for centering the file name label
+                    float verticalOffset = (ImGui.GetTextLineHeight() - fileNameSize.Y) * 0.5f;
+
+                    // Anchor the counter label below the image, centered
+                    ImGui.SetCursorPos(new Vector2(cursorPos.X + buttonWidth + offset, cursorPos.Y));
+                    ImGui.Text(counterLabel);
+
+                    // Anchor the file name label below the counter label, centered
+                    ImGui.SetCursorPos(new Vector2(cursorPos.X + buttonWidth + nameOffset, cursorPos.Y + ImGui.GetTextLineHeight() + verticalOffset));
+                    ImGui.Text(fileName);
+                }
+                else
+                {
+                    ImGui.Text("Failed to load image.");
+                }
+            }
+        }
+
         ImGui.Separator();
 
         ImGuiUtil.TextWrapped(_selector.Selected!.Description);
+    }
+
+    private async Task<IDalamudTextureWrap> LoadImageTextureAsync(string imagePath)
+    {
+        try
+        {
+            using (FileStream fileStream = File.OpenRead(imagePath))
+            {
+                (Image image, _) = await Image.LoadWithFormatAsync(fileStream);
+
+                int targetWidth = 500;
+                int targetHeight = 300;
+
+                image.Mutate(x => x.Resize(new ResizeOptions
+                {
+                    Size = new Size(targetWidth, targetHeight),
+                    Mode = ResizeMode.Stretch
+                }));
+
+                using (MemoryStream stream = new MemoryStream())
+                {
+                    await image.SaveAsync(stream, new PngEncoder());
+
+                    byte[] imageData = stream.ToArray();
+                    return _pi.UiBuilder.LoadImage(imageData);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Penumbra.Log.Error($"Error loading image: {e.Message}");
+            return null!;
+        }
+    }
+    private void OnSelectionChange(Mod? oldSelection, Mod? newSelection, in ModFileSystemSelector.ModState state)
+    {
+        _currentImageIndex = 0;
+        _currentImageTexture = null;
     }
 }

--- a/Penumbra/UI/Tabs/SettingsTab.cs
+++ b/Penumbra/UI/Tabs/SettingsTab.cs
@@ -305,6 +305,9 @@ public class SettingsTab : ITab
         UiHelpers.DefaultLineSpace();
 
         DrawModHandlingSettings();
+        UiHelpers.DefaultLineSpace();
+
+        DrawImagePreviewSettings();
         ImGui.NewLine();
     }
 
@@ -537,6 +540,12 @@ public class SettingsTab : ITab
                 _config.DeleteModModifier = v;
                 _config.Save();
             });
+    }
+
+    /// <summary> Draw all settings pertaining to the mod Preview. </summary>
+    private void DrawImagePreviewSettings()
+    {
+        DrawShowPreviewImagesBox();
     }
 
     /// <summary> Draw all settings pertaining to import and export of mods. </summary>
@@ -833,6 +842,21 @@ public class SettingsTab : ITab
         ImGui.SameLine();
         ImGuiUtil.LabeledHelpMarker("Enable Debug Mode",
             "[DEBUG] Enable the Debug Tab and Resource Manager Tab as well as some additional data collection. Also open the config window on plugin load.");
+    }
+
+    /// <summary> Draw a checkbox to toggle preview images. </summary>
+    private void DrawShowPreviewImagesBox()
+    {
+        var tmp = _config.ShowPreviewImages;
+        if (ImGui.Checkbox("##showPreviewImages", ref tmp) && tmp != _config.ShowPreviewImages)
+        {
+            _config.ShowPreviewImages = tmp;
+            _config.Save();
+        }
+
+        ImGui.SameLine();
+        ImGuiUtil.LabeledHelpMarker("Show Preview Images",
+            "Enable or disable the showing of preview images loaded from a mod in its' description tab.");
     }
 
     /// <summary> Draw a button that reloads resident resources. </summary>

--- a/repo.json
+++ b/repo.json
@@ -1,12 +1,12 @@
 [
   {
-    "Author": "Ottermandias, Adam, Wintermute",
-    "Name": "Penumbra",
+    "Author": "Ottermandias, Adam, Wintermute (modifications by aniachan)",
+    "Name": "Penumbra (aniachan ver.)",
     "Description": "Runtime mod loader and manager.",
     "InternalName": "Penumbra",
     "AssemblyVersion": "0.8.3.1",
     "TestingAssemblyVersion": "0.8.3.5",
-    "RepoUrl": "https://github.com/xivdev/Penumbra",
+    "RepoUrl": "https://github.com/aniachan/Penumbra",
     "ApplicableVersion": "any",
     "DalamudApiLevel": 9,
     "IsHide": "False",
@@ -16,9 +16,9 @@
     "LoadPriority": 69420,
     "LoadRequiredState": 2,
     "LoadSync": true,
-    "DownloadLinkInstall": "https://github.com/xivdev/Penumbra/releases/download/0.8.3.1/Penumbra.zip",
-    "DownloadLinkTesting": "https://github.com/xivdev/Penumbra/releases/download/testing_0.8.3.5/Penumbra.zip",
-    "DownloadLinkUpdate": "https://github.com/xivdev/Penumbra/releases/download/0.8.3.1/Penumbra.zip",
-    "IconUrl": "https://raw.githubusercontent.com/xivdev/Penumbra/master/images/icon.png"
+    "DownloadLinkInstall": "https://github.com/aniachan/penumbra/releases/download/0.8.3.1-ania/Penumbra.zip",
+    "DownloadLinkTesting": "https://github.com/aniachan/penumbra/releases/download/0.8.3.1-ania/Penumbra.zip",
+    "DownloadLinkUpdate": "https://github.com/aniachan/Penumbra/releases/download/0.8.3.1-ania/Penumbra.zip",
+    "IconUrl": "https://raw.githubusercontent.com/aniachan/Penumbra/master/images/icon.png"
   }
 ]


### PR DESCRIPTION
# Image Preview
I am creating this PR in order to implement image previews to be shown on mod pages.

## Reasoning: 
When users have a large number of mods installed (often in the hundreds), it is often quite difficult to determine what the mods actually contain. It is true that the user can manually enable each mod and see what it overrides, this takes quite a lot of time. 

As such, I am proposing a change to Penumbra which will allow the viewing of preview images in the mod description window.

## Background

Originally this idea came from the fact that TexTools has images which are provided as a part of its' mod installer, and these images can be imported and used in Penumbra in order to view what a mod actually is.

We can take advantage of this and import these images for viewing in Penumbra in addition to allowing users to add new images to existing mods via the UI or the file system. 

## Implementation

### Structure

Just as in a TexTools mod, a directory called `images` in the root of the mod installer is used to contain the preview images for a particular mod.

#### Archive / PMP Mod

When an archive mod is loaded in the Penumbra format, the `/images` directory is also loaded into the user's Penumbra directory.

#### TexTools Extended Mod 

For ttmp2 extended modpacks, the JSON file is parsed and ImagePath entries are used along with the option name to import new preview images for the destination mod. 

### UI

The UI consists of three segments, an update to the Settings page, an option to import new preview images, and the mod description page itself.

#### Description

The description page now contains both the description text and the preview image viewer. The preview image along with the number of images available (since there may be more than one), and the image name.

I chose to add the image name as a label due to the fact that for TexTools mods, the images are related to options and not the mod as a whole. By specifying the name of the option during import, the images are much more useful.

<img width="274" alt="image" src="https://github.com/xivdev/Penumbra/assets/114481197/421186ab-c652-4d51-9860-f91bc19cfd8a">

#### Import

On the "Edit Mod" tab, there is now an option to import new preview images for mods that don't have any. 

<img width="335" alt="image" src="https://github.com/xivdev/Penumbra/assets/114481197/18f62a46-339f-47b2-bea5-c22ff22c454e">

#### Settings

General settings now has a toggle to enable or disable image previews for those who may not want them. 

![image](https://github.com/xivdev/Penumbra/assets/114481197/ee38feee-df5d-4e7c-a75e-7087033a639a)

## Request

Please review my pull request and let me know what you think of the idea in general, my implementation specifically, and whether there are any changes or improvements I could make. 