### PR TITLE
Fix -- texture prefixing in ResourceTree

### DIFF
--- a/Penumbra/Interop/ResourceTree/ResolveContext.cs
+++ b/Penumbra/Interop/ResourceTree/ResolveContext.cs
@@ -48,8 +48,9 @@ internal record class ResolveContext(Configuration Config, IObjectIdentifier Ide
                 prefixed[lastDirectorySeparator + 1] = (byte)'-';
                 prefixed[lastDirectorySeparator + 2] = (byte)'-';
                 gamePath.Span[(lastDirectorySeparator + 1)..].CopyTo(prefixed[(lastDirectorySeparator + 3)..]);
+                prefixed[^1] = 0;
 
-                if (!Utf8GamePath.FromSpan(prefixed, out var tmp))
+                if (!Utf8GamePath.FromSpan(prefixed[..^1], out var tmp))
                     return null;
 
                 gamePath = tmp.Path.Clone();

--- a/Penumbra/Interop/ResourceTree/ResolveContext.cs
+++ b/Penumbra/Interop/ResourceTree/ResolveContext.cs
@@ -43,14 +43,13 @@ internal record class ResolveContext(Configuration Config, IObjectIdentifier Ide
 
             if (gamePath[lastDirectorySeparator + 1] != (byte)'-' || gamePath[lastDirectorySeparator + 2] != (byte)'-')
             {
-                Span<byte> prefixed = stackalloc byte[gamePath.Length + 3];
+                Span<byte> prefixed = stackalloc byte[gamePath.Length + 2];
                 gamePath.Span[..(lastDirectorySeparator + 1)].CopyTo(prefixed);
                 prefixed[lastDirectorySeparator + 1] = (byte)'-';
                 prefixed[lastDirectorySeparator + 2] = (byte)'-';
                 gamePath.Span[(lastDirectorySeparator + 1)..].CopyTo(prefixed[(lastDirectorySeparator + 3)..]);
-                prefixed[^1] = 0;
 
-                if (!Utf8GamePath.FromSpan(prefixed[..^1], out var tmp))
+                if (!Utf8GamePath.FromSpan(prefixed, out var tmp))
                     return null;
 
                 gamePath = tmp.Path.Clone();


### PR DESCRIPTION
This makes the null terminator not part of the `Utf8GamePath` representing the prefixed texture paths to fix `ResourceTree` problems. It's still kept in memory for any indirect callees that could take C `char*`s.

Also, the null terminator is now explicitly written at the end of the memory block, as `stackalloc` zero-inits the memory in practice, but leaves it undefined in the C# spec.