### PR TITLE
Add a filter to the selection combo inside textures tab

### DIFF
--- a/Penumbra/Import/Textures/Texture.cs
+++ b/Penumbra/Import/Textures/Texture.cs
@@ -229,10 +229,7 @@ public sealed class Texture : IDisposable
         ImGui.SetNextItemWidth(-0.0001f);
         var startPath = Path.Length > 0 ? Path : "Choose a modded texture from this mod here...";
 
-        //ImGui.PushStyleVar(ImGuiStyleVar.ScrollbarSize, 0f);
-        //ImGui.PushStyleVar(ImGuiStyleVar.ScrollbarRounding, 0f);
         using var combo = ImRaii.Combo(label, startPath);
-        //ImGui.PopStyleVar(2);
 
         if (combo)
         {
@@ -247,8 +244,7 @@ public sealed class Texture : IDisposable
             }
             else
             {
-                filter.Trim();
-                filteredPaths = paths.Where(path => (path.Item1.ToLower().Contains(filter.ToLower())));
+                filteredPaths = paths.Where(path => path.Item1.ToLower().Contains(filter.Trim().ToLower()));
             }
             var height = (ImGui.GetFrameHeight() - 3.3f) * Math.Min(filteredPaths.Count(), 7);
             ImGui.BeginChild("ComboScrollingRegion", new Vector2(0, height), false);

--- a/Penumbra/Import/Textures/Texture.cs
+++ b/Penumbra/Import/Textures/Texture.cs
@@ -229,12 +229,10 @@ public sealed class Texture : IDisposable
         ImGui.SetNextItemWidth(-0.0001f);
         var startPath = Path.Length > 0 ? Path : "Choose a modded texture from this mod here...";
 
-        //ImRaii.PushStyle(ImGuiStyleVar.ScrollbarSize, 0f);
-        //ImRaii.PushStyle(ImGuiStyleVar.ScrollbarRounding, 0f);
-        ImGui.PushStyleVar(ImGuiStyleVar.ScrollbarSize, 0f);
-        ImGui.PushStyleVar(ImGuiStyleVar.ScrollbarRounding, 0f);
+        //ImGui.PushStyleVar(ImGuiStyleVar.ScrollbarSize, 0f);
+        //ImGui.PushStyleVar(ImGuiStyleVar.ScrollbarRounding, 0f);
         using var combo = ImRaii.Combo(label, startPath);
-        ImGui.PopStyleVar(2);
+        //ImGui.PopStyleVar(2);
 
         if (combo)
         {
@@ -252,7 +250,7 @@ public sealed class Texture : IDisposable
                 filter.Trim();
                 filteredPaths = paths.Where(path => (path.Item1.ToLower().Contains(filter.ToLower())));
             }
-            var height = ImGui.GetFrameHeightWithSpacing() * Math.Min(filteredPaths.Count(), 7);
+            var height = (ImGui.GetFrameHeight() - 3.3f) * Math.Min(filteredPaths.Count(), 7);
             ImGui.BeginChild("ComboScrollingRegion", new Vector2(0, height), false);
 
             foreach (var ((path, game), idx) in filteredPaths.WithIndex())

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Textures.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Textures.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using ImGuiNET;
 using OtterGui;
+using OtterGui.Classes;
 using OtterGui.Raii;
 using OtterTex;
 using Penumbra.Import.Textures;
@@ -20,6 +21,8 @@ public partial class ModEditWindow
 
     private bool _addMipMaps = true;
     private int  _currentSaveAs;
+
+    private LowerString _filter = LowerString.Empty;
 
     private static readonly (string, string)[] SaveAsStrings =
     {
@@ -48,7 +51,7 @@ public partial class ModEditWindow
             .Prepend((f.File.FullName, false)));
         tex.PathSelectBox(_dalamud, "##combo",
             "Select the textures included in this mod on your drive or the ones they replace from the game files.",
-            files, _mod.ModPath.FullName.Length + 1);
+            files, _mod.ModPath.FullName.Length + 1, _filter);
 
         if (tex == _left)
             _center.DrawMatrixInputLeft(size.X);


### PR DESCRIPTION
I'm fairly sure this isn't the desired solution, but I can't figure out how the OtterGui filter combo boxes are created and called, or how to draw it instead of the existing selection box. On the off-chance that someone feels like eli5 that stuff, I'm more than willing to make the changes in the PR, otherwise this is all I could come up with.