### PR TITLE
Material editor 2099

### DIFF
--- a/Penumbra/Interop/ResourceTree/ResolveContext.cs
+++ b/Penumbra/Interop/ResourceTree/ResolveContext.cs
@@ -190,7 +190,7 @@ internal record class ResolveContext(Configuration Config, IObjectIdentifier Ide
 
             if (WithNames)
             {
-                var name = samplers != null && i < samplers.Count ? samplers[i].Item2?.Name : null;
+                var name = samplers != null && i < samplers.Length ? samplers[i].ShpkSampler?.Name : null;
                 node.Children.Add(texNode.WithName(name ?? $"Texture #{i}"));
             }
             else

--- a/Penumbra/Interop/SafeHandles/SafeTextureHandle.cs
+++ b/Penumbra/Interop/SafeHandles/SafeTextureHandle.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Render;
+using Penumbra.Interop.Structs;
+
+namespace Penumbra.Interop.SafeHandles;
+
+public unsafe class SafeTextureHandle : SafeHandle
+{
+    public Texture* Texture => (Texture*)handle;
+
+    public override bool IsInvalid => handle == 0;
+
+    public SafeTextureHandle(Texture* handle, bool incRef, bool ownsHandle = true) : base(0, ownsHandle)
+    {
+        if (incRef && !ownsHandle)
+            throw new ArgumentException("Non-owning SafeTextureHandle with IncRef is unsupported");
+        if (incRef && handle != null)
+            TextureUtility.IncRef(handle);
+        SetHandle((nint)handle);
+    }
+
+    public void Exchange(ref nint ppTexture)
+    {
+        lock (this)
+        {
+            handle = Interlocked.Exchange(ref ppTexture, handle);
+        }
+    }
+
+    public static SafeTextureHandle CreateInvalid()
+        => new(null, incRef: false);
+
+    protected override bool ReleaseHandle()
+    {
+        nint handle;
+        lock (this)
+        {
+            handle = this.handle;
+            this.handle = 0;
+        }
+        if (handle != 0)
+            TextureUtility.DecRef((Texture*)handle);
+
+        return true;
+    }
+}

--- a/Penumbra/Interop/Structs/CharacterBaseExt.cs
+++ b/Penumbra/Interop/Structs/CharacterBaseExt.cs
@@ -1,0 +1,15 @@
+using System.Runtime.InteropServices;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Render;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
+
+namespace Penumbra.Interop.Structs;
+
+[StructLayout( LayoutKind.Explicit )]
+public unsafe struct CharacterBaseExt
+{
+    [FieldOffset( 0x0 )]
+    public CharacterBase CharacterBase;
+
+    [FieldOffset( 0x258 )]
+    public Texture** ColorSetTextures;
+}

--- a/Penumbra/Interop/Structs/ConstantBuffer.cs
+++ b/Penumbra/Interop/Structs/ConstantBuffer.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Penumbra.Interop.Structs;
+
+[StructLayout(LayoutKind.Explicit, Size = 0x70)]
+public unsafe struct ConstantBuffer
+{
+    [FieldOffset(0x20)]
+    public int Size;
+
+    [FieldOffset(0x24)]
+    public int Flags;
+
+    [FieldOffset(0x28)]
+    private void* _maybeSourcePointer;
+
+    public bool TryGetBuffer(out Span<float> buffer)
+    {
+        if ((Flags & 0x4003) == 0 && _maybeSourcePointer != null)
+        {
+            buffer = new Span<float>(_maybeSourcePointer, Size >> 2);
+            return true;
+        }
+        else
+        {
+            buffer = null;
+            return false;
+        }
+    }
+}

--- a/Penumbra/Interop/Structs/HumanExt.cs
+++ b/Penumbra/Interop/Structs/HumanExt.cs
@@ -9,6 +9,9 @@ public unsafe struct HumanExt
     [FieldOffset( 0x0 )]
     public Human Human;
 
+    [FieldOffset( 0x0 )]
+    public CharacterBaseExt CharacterBase;
+
     [FieldOffset( 0x9E8 )]
     public ResourceHandle* Decal;
 

--- a/Penumbra/Interop/Structs/Material.cs
+++ b/Penumbra/Interop/Structs/Material.cs
@@ -3,17 +3,42 @@ using FFXIVClientStructs.FFXIV.Client.Graphics.Render;
 
 namespace Penumbra.Interop.Structs;
 
-[StructLayout( LayoutKind.Explicit )]
+[StructLayout( LayoutKind.Explicit, Size = 0x40 )]
 public unsafe struct Material
 {
     [FieldOffset( 0x10 )]
-    public ResourceHandle* ResourceHandle;
+    public MtrlResource* ResourceHandle;
+
+    [FieldOffset( 0x18 )]
+    public uint ShaderPackageFlags;
+
+    [FieldOffset( 0x20 )]
+    public uint* ShaderKeys;
+
+    public int ShaderKeyCount
+        => (int)((uint*)Textures - ShaderKeys);
 
     [FieldOffset( 0x28 )]
-    public void* MaterialData;
+    public ConstantBuffer* MaterialParameter;
 
     [FieldOffset( 0x30 )]
-    public void** Textures;
+    public TextureEntry* Textures;
 
-    public Texture* Texture( int index ) => ( Texture* )Textures[3 * index + 1];
+    [FieldOffset( 0x38 )]
+    public ushort TextureCount;
+
+    public Texture* Texture( int index ) => Textures[index].ResourceHandle->KernelTexture;
+
+    [StructLayout( LayoutKind.Explicit, Size = 0x18 )]
+    public struct TextureEntry
+    {
+        [FieldOffset( 0x00 )]
+        public uint Id;
+
+        [FieldOffset( 0x08 )]
+        public TextureResourceHandle* ResourceHandle;
+
+        [FieldOffset( 0x10 )]
+        public uint SamplerFlags;
+    }
 }

--- a/Penumbra/Interop/Structs/MtrlResource.cs
+++ b/Penumbra/Interop/Structs/MtrlResource.cs
@@ -8,8 +8,11 @@ public unsafe struct MtrlResource
     [FieldOffset( 0x00 )]
     public ResourceHandle Handle;
 
+    [FieldOffset( 0xC8 )]
+    public ShaderPackageResourceHandle* ShpkResourceHandle;
+
     [FieldOffset( 0xD0 )]
-    public ushort* TexSpace; // Contains the offsets for the tex files inside the string list.
+    public TextureEntry* TexSpace; // Contains the offsets for the tex files inside the string list.
 
     [FieldOffset( 0xE0 )]
     public byte* StringList;
@@ -24,8 +27,21 @@ public unsafe struct MtrlResource
         => StringList + ShpkOffset;
 
     public byte* TexString( int idx )
-        => StringList + *( TexSpace + 4 + idx * 8 );
+        => StringList + TexSpace[idx].PathOffset;
 
     public bool TexIsDX11( int idx )
-        => *(TexSpace + 5 + idx * 8) >= 0x8000;
+        => TexSpace[idx].Flags >= 0x8000;
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x10)]
+    public struct TextureEntry
+    {
+        [FieldOffset( 0x00 )]
+        public TextureResourceHandle* ResourceHandle;
+
+        [FieldOffset( 0x08 )]
+        public ushort PathOffset;
+
+        [FieldOffset( 0x0A )]
+        public ushort Flags;
+    }
 }

--- a/Penumbra/Interop/Structs/ResourceHandle.cs
+++ b/Penumbra/Interop/Structs/ResourceHandle.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Kernel;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Render;
 using FFXIVClientStructs.FFXIV.Client.System.Resource;
 using Penumbra.GameData;
 using Penumbra.GameData.Enums;
@@ -18,10 +20,20 @@ public unsafe struct TextureResourceHandle
     public IntPtr Unk;
 
     [FieldOffset( 0x118 )]
-    public IntPtr KernelTexture;
+    public Texture* KernelTexture;
 
     [FieldOffset( 0x20 )]
     public IntPtr NewKernelTexture;
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public unsafe struct ShaderPackageResourceHandle
+{
+    [FieldOffset( 0x0 )]
+    public ResourceHandle Handle;
+
+    [FieldOffset( 0xB0 )]
+    public ShaderPackage* ShaderPackage;
 }
 
 [StructLayout( LayoutKind.Explicit )]

--- a/Penumbra/Interop/Structs/ShaderPackageUtility.cs
+++ b/Penumbra/Interop/Structs/ShaderPackageUtility.cs
@@ -1,0 +1,19 @@
+using System.Runtime.InteropServices;
+
+namespace Penumbra.Interop.Structs;
+
+public static class ShaderPackageUtility
+{
+    [StructLayout(LayoutKind.Explicit, Size = 0xC)]
+    public unsafe struct Sampler
+    {
+        [FieldOffset(0x0)]
+        public uint Crc;
+
+        [FieldOffset(0x4)]
+        public uint Id;
+
+        [FieldOffset(0xA)]
+        public ushort Slot;
+    }
+}

--- a/Penumbra/Interop/Structs/TextureUtility.cs
+++ b/Penumbra/Interop/Structs/TextureUtility.cs
@@ -1,0 +1,36 @@
+using Dalamud.Utility.Signatures;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Kernel;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Render;
+
+namespace Penumbra.Interop.Structs;
+
+public unsafe static class TextureUtility
+{
+    private static readonly Functions Funcs = new();
+
+    public static Texture* Create2D(Device* device, int* size, byte mipLevel, uint textureFormat, uint flags, uint unk)
+        => ((delegate* unmanaged<Device*, int*, byte, uint, uint, uint, Texture*>)Funcs.TextureCreate2D)(device, size, mipLevel, textureFormat, flags, unk);
+
+    public static bool InitializeContents(Texture* texture, void* contents)
+        => ((delegate* unmanaged<Texture*, void*, bool>)Funcs.TextureInitializeContents)(texture, contents);
+
+    public static void IncRef(Texture* texture)
+        => ((delegate* unmanaged<Texture*, void>)(*(void***)texture)[2])(texture);
+
+    public static void DecRef(Texture* texture)
+        => ((delegate* unmanaged<Texture*, void>)(*(void***)texture)[3])(texture);
+
+    private sealed class Functions
+    {
+        [Signature("E8 ?? ?? ?? ?? 8B 0F 48 8D 54 24")]
+        public nint TextureCreate2D = nint.Zero;
+
+        [Signature("E9 ?? ?? ?? ?? 8B 02 25")]
+        public nint TextureInitializeContents = nint.Zero;
+
+        public Functions()
+        {
+            SignatureHelper.Initialise(this);
+        }
+    }
+}

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.ColorSet.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.ColorSet.cs
@@ -412,12 +412,13 @@ public partial class ModEditWindow
     private static bool ColorPicker( string label, string tooltip, Vector3 input, Action< Vector3 > setter, string letter = "" )
     {
         var ret = false;
-        var tmp = input;
+        var inputSqrt = Vector3.SquareRoot( input );
+        var tmp = inputSqrt;
         if( ImGui.ColorEdit3( label, ref tmp,
                ImGuiColorEditFlags.NoInputs | ImGuiColorEditFlags.DisplayRGB | ImGuiColorEditFlags.InputRGB | ImGuiColorEditFlags.NoTooltip )
-        && tmp != input )
+        && tmp != inputSqrt )
         {
-            setter( tmp );
+            setter( tmp * tmp );
             ret = true;
         }
 

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.ColorSet.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.ColorSet.cs
@@ -483,13 +483,13 @@ public partial class ModEditWindow
     private static bool ColorPicker( string label, string tooltip, Vector3 input, Action< Vector3 > setter, string letter = "" )
     {
         var ret = false;
-        var inputSqrt = Vector3.SquareRoot( input );
+        var inputSqrt = PseudoSqrtRgb( input );
         var tmp = inputSqrt;
         if( ImGui.ColorEdit3( label, ref tmp,
-               ImGuiColorEditFlags.NoInputs | ImGuiColorEditFlags.DisplayRGB | ImGuiColorEditFlags.InputRGB | ImGuiColorEditFlags.NoTooltip )
+               ImGuiColorEditFlags.NoInputs | ImGuiColorEditFlags.DisplayRGB | ImGuiColorEditFlags.InputRGB | ImGuiColorEditFlags.NoTooltip | ImGuiColorEditFlags.HDR )
         && tmp != inputSqrt )
         {
-            setter( tmp * tmp );
+            setter( PseudoSquareRgb( tmp ) );
             ret = true;
         }
 
@@ -505,4 +505,24 @@ public partial class ModEditWindow
 
         return ret;
     }
+
+    // Functions to deal with squared RGB values without making negatives useless.
+
+    private static float PseudoSquareRgb(float x)
+        => x < 0.0f ? -(x * x) : (x * x);
+
+    private static Vector3 PseudoSquareRgb(Vector3 vec)
+        => new(PseudoSquareRgb(vec.X), PseudoSquareRgb(vec.Y), PseudoSquareRgb(vec.Z));
+
+    private static Vector4 PseudoSquareRgb(Vector4 vec)
+        => new(PseudoSquareRgb(vec.X), PseudoSquareRgb(vec.Y), PseudoSquareRgb(vec.Z), vec.W);
+
+    private static float PseudoSqrtRgb(float x)
+        => x < 0.0f ? -MathF.Sqrt(-x) : MathF.Sqrt(x);
+
+    private static Vector3 PseudoSqrtRgb(Vector3 vec)
+        => new(PseudoSqrtRgb(vec.X), PseudoSqrtRgb(vec.Y), PseudoSqrtRgb(vec.Z));
+
+    private static Vector4 PseudoSqrtRgb(Vector4 vec)
+        => new(PseudoSqrtRgb(vec.X), PseudoSqrtRgb(vec.Y), PseudoSqrtRgb(vec.Z), vec.W);
 }

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.ConstantEditor.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.ConstantEditor.cs
@@ -147,11 +147,11 @@ public partial class ModEditWindow
                 ImGui.SetNextItemWidth(editorWidth);
                 var value = new Vector3(values);
                 if (_squaredRgb)
-                    value = Vector3.SquareRoot(value);
+                    value = PseudoSqrtRgb(value);
                 if (ImGui.ColorEdit3("##0", ref value, ImGuiColorEditFlags.Float | (_clamped ? 0 : ImGuiColorEditFlags.HDR)) && !disabled)
                 {
                     if (_squaredRgb)
-                        value *= value;
+                        value = PseudoSquareRgb(value);
                     if (_clamped)
                         value = Vector3.Clamp(value, Vector3.Zero, Vector3.One);
                     value.CopyTo(values);
@@ -165,11 +165,11 @@ public partial class ModEditWindow
                 ImGui.SetNextItemWidth(editorWidth);
                 var value = new Vector4(values);
                 if (_squaredRgb)
-                    value = new Vector4(MathF.Sqrt(value.X), MathF.Sqrt(value.Y), MathF.Sqrt(value.Z), value.W);
+                    value = PseudoSqrtRgb(value);
                 if (ImGui.ColorEdit4("##0", ref value, ImGuiColorEditFlags.Float | ImGuiColorEditFlags.AlphaPreviewHalf | (_clamped ? 0 : ImGuiColorEditFlags.HDR)) && !disabled)
                 {
                     if (_squaredRgb)
-                        value *= new Vector4(value.X, value.Y, value.Z, 1.0f);
+                        value = PseudoSquareRgb(value);
                     if (_clamped)
                         value = Vector4.Clamp(value, Vector4.Zero, Vector4.One);
                     value.CopyTo(values);

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.ConstantEditor.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.ConstantEditor.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using ImGuiNET;
+using OtterGui.Raii;
+using OtterGui;
+using Penumbra.GameData;
+
+namespace Penumbra.UI.AdvancedWindow;
+
+public partial class ModEditWindow
+{
+    private interface IConstantEditor
+    {
+        bool Draw(Span<float> values, bool disabled, float editorWidth);
+    }
+
+    private sealed class FloatConstantEditor : IConstantEditor
+    {
+        public static readonly FloatConstantEditor Default = new(null, null, 0.1f, 0.0f, 1.0f, 0.0f, 3, string.Empty);
+
+        private readonly float? _minimum;
+        private readonly float? _maximum;
+        private readonly float  _speed;
+        private readonly float  _relativeSpeed;
+        private readonly float  _factor;
+        private readonly float  _bias;
+        private readonly string _format;
+
+        public FloatConstantEditor(float? minimum, float? maximum, float speed, float relativeSpeed, float factor, float bias, byte precision, string unit)
+        {
+            _minimum       = minimum;
+            _maximum       = maximum;
+            _speed         = speed;
+            _relativeSpeed = relativeSpeed;
+            _factor        = factor;
+            _bias          = bias;
+            _format        = $"%.{Math.Min(precision, (byte)9)}f";
+            if (unit.Length > 0)
+                _format = $"{_format} {unit.Replace("%", "%%")}";
+        }
+
+        public bool Draw(Span<float> values, bool disabled, float editorWidth)
+        {
+            var fieldWidth = (editorWidth - (values.Length - 1) * ImGui.GetStyle().ItemSpacing.X) / values.Length;
+
+            var ret = false;
+
+            for (var valueIdx = 0; valueIdx < values.Length; ++valueIdx)
+            {
+                if (valueIdx > 0)
+                    ImGui.SameLine();
+
+                ImGui.SetNextItemWidth(MathF.Round(fieldWidth * (valueIdx + 1)) - MathF.Round(fieldWidth * valueIdx));
+
+                var value = (values[valueIdx] - _bias) / _factor;
+                if (disabled)
+                    ImGui.DragFloat($"##{valueIdx}", ref value, Math.Max(_speed, value * _relativeSpeed), value, value, _format);
+                else
+                {
+                    if (ImGui.DragFloat($"##{valueIdx}", ref value, Math.Max(_speed, value * _relativeSpeed), _minimum ?? 0.0f, _maximum ?? 0.0f, _format))
+                    {
+                        values[valueIdx] = Clamp(value) * _factor + _bias;
+                        ret              = true;
+                    }
+                }
+            }
+
+            return ret;
+        }
+
+        private float Clamp(float value)
+            => Math.Clamp(value, _minimum ?? float.NegativeInfinity, _maximum ?? float.PositiveInfinity);
+    }
+
+    private sealed class IntConstantEditor : IConstantEditor
+    {
+        private readonly int?   _minimum;
+        private readonly int?   _maximum;
+        private readonly float  _speed;
+        private readonly float  _relativeSpeed;
+        private readonly float  _factor;
+        private readonly float  _bias;
+        private readonly string _format;
+
+        public IntConstantEditor(int? minimum, int? maximum, float speed, float relativeSpeed, float factor, float bias, string unit)
+        {
+            _minimum       = minimum;
+            _maximum       = maximum;
+            _speed         = speed;
+            _relativeSpeed = relativeSpeed;
+            _factor        = factor;
+            _bias          = bias;
+            _format        = "%d";
+            if (unit.Length > 0)
+                _format = $"{_format} {unit.Replace("%", "%%")}";
+        }
+
+        public bool Draw(Span<float> values, bool disabled, float editorWidth)
+        {
+            var fieldWidth = (editorWidth - (values.Length - 1) * ImGui.GetStyle().ItemSpacing.X) / values.Length;
+
+            var ret = false;
+
+            for (var valueIdx = 0; valueIdx < values.Length; ++valueIdx)
+            {
+                if (valueIdx > 0)
+                    ImGui.SameLine();
+
+                ImGui.SetNextItemWidth(MathF.Round(fieldWidth * (valueIdx + 1)) - MathF.Round(fieldWidth * valueIdx));
+
+                var value = (int)Math.Clamp(MathF.Round((values[valueIdx] - _bias) / _factor), int.MinValue, int.MaxValue);
+                if (disabled)
+                    ImGui.DragInt($"##{valueIdx}", ref value, Math.Max(_speed, value * _relativeSpeed), value, value, _format);
+                else
+                {
+                    if (ImGui.DragInt($"##{valueIdx}", ref value, Math.Max(_speed, value * _relativeSpeed), _minimum ?? 0, _maximum ?? 0, _format))
+                    {
+                        values[valueIdx] = Clamp(value) * _factor + _bias;
+                        ret              = true;
+                    }
+                }
+            }
+
+            return ret;
+        }
+
+        private int Clamp(int value)
+            => Math.Clamp(value, _minimum ?? int.MinValue, _maximum ?? int.MaxValue);
+    }
+
+    private sealed class ColorConstantEditor : IConstantEditor
+    {
+        private readonly bool _squaredRgb;
+        private readonly bool _clamped;
+
+        public ColorConstantEditor(bool squaredRgb, bool clamped)
+        {
+            _squaredRgb = squaredRgb;
+            _clamped    = clamped;
+        }
+
+        public bool Draw(Span<float> values, bool disabled, float editorWidth)
+        {
+            if (values.Length == 3)
+            {
+                ImGui.SetNextItemWidth(editorWidth);
+                var value = new Vector3(values);
+                if (_squaredRgb)
+                    value = Vector3.SquareRoot(value);
+                if (ImGui.ColorEdit3("##0", ref value) && !disabled)
+                {
+                    if (_squaredRgb)
+                        value *= value;
+                    if (_clamped)
+                        value = Vector3.Clamp(value, Vector3.Zero, Vector3.One);
+                    value.CopyTo(values);
+                    return true;
+                }
+
+                return false;
+            }
+            else if (values.Length == 4)
+            {
+                ImGui.SetNextItemWidth(editorWidth);
+                var value = new Vector4(values);
+                if (_squaredRgb)
+                    value = new Vector4(MathF.Sqrt(value.X), MathF.Sqrt(value.Y), MathF.Sqrt(value.Z), value.W);
+                if (ImGui.ColorEdit4("##0", ref value) && !disabled)
+                {
+                    if (_squaredRgb)
+                        value *= new Vector4(value.X, value.Y, value.Z, 1.0f);
+                    if (_clamped)
+                        value = Vector4.Clamp(value, Vector4.Zero, Vector4.One);
+                    value.CopyTo(values);
+                    return true;
+                }
+
+                return false;
+            }
+            else
+                return FloatConstantEditor.Default.Draw(values, disabled, editorWidth);
+        }
+    }
+
+    private sealed class EnumConstantEditor : IConstantEditor
+    {
+        private readonly IReadOnlyList<(string Label, float Value, string Description)> _values;
+
+        public EnumConstantEditor(IReadOnlyList<(string Label, float Value, string Description)> values)
+        {
+            _values = values;
+        }
+
+        public bool Draw(Span<float> values, bool disabled, float editorWidth)
+        {
+            var fieldWidth = (editorWidth - (values.Length - 1) * ImGui.GetStyle().ItemSpacing.X) / values.Length;
+
+            var ret = false;
+
+            for (var valueIdx = 0; valueIdx < values.Length; ++valueIdx)
+            {
+                if (valueIdx > 0)
+                    ImGui.SameLine();
+
+                ImGui.SetNextItemWidth(MathF.Round(fieldWidth * (valueIdx + 1)) - MathF.Round(fieldWidth * valueIdx));
+
+                var currentValue = values[valueIdx];
+                var (currentLabel, _, currentDescription) = _values.FirstOrNull(v => v.Value == currentValue) ?? (currentValue.ToString(), currentValue, string.Empty);
+                if (disabled)
+                    ImGui.InputText($"##{valueIdx}", ref currentLabel, (uint)currentLabel.Length, ImGuiInputTextFlags.ReadOnly);
+                else
+                {
+                    using var c = ImRaii.Combo($"##{valueIdx}", currentLabel);
+                    {
+                        if (c)
+                            foreach (var (valueLabel, value, valueDescription) in _values)
+                            {
+                                if (ImGui.Selectable(valueLabel, value == currentValue))
+                                {
+                                    values[valueIdx] = value;
+                                    ret              = true;
+                                }
+
+                                if (valueDescription.Length > 0)
+                                    ImGuiUtil.SelectableHelpMarker(valueDescription);
+                            }
+                    }
+                }
+            }
+
+            return ret;
+        }
+    }
+}

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.ConstantEditor.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.ConstantEditor.cs
@@ -148,7 +148,7 @@ public partial class ModEditWindow
                 var value = new Vector3(values);
                 if (_squaredRgb)
                     value = Vector3.SquareRoot(value);
-                if (ImGui.ColorEdit3("##0", ref value) && !disabled)
+                if (ImGui.ColorEdit3("##0", ref value, ImGuiColorEditFlags.Float | (_clamped ? 0 : ImGuiColorEditFlags.HDR)) && !disabled)
                 {
                     if (_squaredRgb)
                         value *= value;
@@ -166,7 +166,7 @@ public partial class ModEditWindow
                 var value = new Vector4(values);
                 if (_squaredRgb)
                     value = new Vector4(MathF.Sqrt(value.X), MathF.Sqrt(value.Y), MathF.Sqrt(value.Z), value.W);
-                if (ImGui.ColorEdit4("##0", ref value) && !disabled)
+                if (ImGui.ColorEdit4("##0", ref value, ImGuiColorEditFlags.Float | ImGuiColorEditFlags.AlphaPreviewHalf | (_clamped ? 0 : ImGuiColorEditFlags.HDR)) && !disabled)
                 {
                     if (_squaredRgb)
                         value *= new Vector4(value.X, value.Y, value.Z, 1.0f);

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.LivePreview.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.LivePreview.cs
@@ -398,7 +398,7 @@ public partial class ModEditWindow
             if (mtrlHandle == null)
                 throw new InvalidOperationException("Material doesn't have a resource handle");
 
-            var colorSetTextures = *(Texture***)((nint)DrawObject + 0x258);
+            var colorSetTextures = ((Structs.CharacterBaseExt*)DrawObject)->ColorSetTextures;
             if (colorSetTextures == null)
                 throw new InvalidOperationException("Draw object doesn't have color set textures");
 
@@ -424,7 +424,8 @@ public partial class ModEditWindow
             if (reset)
             {
                 var oldTexture = (Texture*)Interlocked.Exchange(ref *(nint*)_colorSetTexture, (nint)_originalColorSetTexture);
-                Structs.TextureUtility.DecRef(oldTexture);
+                if (oldTexture != null)
+                    Structs.TextureUtility.DecRef(oldTexture);
             }
             else
                 Structs.TextureUtility.DecRef(_originalColorSetTexture);
@@ -460,7 +461,8 @@ public partial class ModEditWindow
             if (success)
             {
                 var oldTexture = (Texture*)Interlocked.Exchange(ref *(nint*)_colorSetTexture, (nint)newTexture);
-                Structs.TextureUtility.DecRef(oldTexture);
+                if (oldTexture != null)
+                    Structs.TextureUtility.DecRef(oldTexture);
             }
             else
                 Structs.TextureUtility.DecRef(newTexture);
@@ -471,7 +473,7 @@ public partial class ModEditWindow
             if (!base.IsStillValid())
                 return false;
 
-            var colorSetTextures = *(Texture***)((nint)DrawObject + 0x258);
+            var colorSetTextures = ((Structs.CharacterBaseExt*)DrawObject)->ColorSetTextures;
             if (colorSetTextures == null)
                 return false;
 

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.LivePreview.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.LivePreview.cs
@@ -1,0 +1,484 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Dalamud.Game;
+using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.Game.Character;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Kernel;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Render;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
+using Penumbra.GameData.Files;
+using Penumbra.Interop.ResourceTree;
+using Structs = Penumbra.Interop.Structs;
+
+namespace Penumbra.UI.AdvancedWindow;
+
+public partial class ModEditWindow
+{
+    private static unsafe Character* FindLocalPlayer(IObjectTable objects)
+    {
+        var localPlayer = objects[0];
+        if (localPlayer is not Dalamud.Game.ClientState.Objects.Types.Character)
+            return null;
+
+        return (Character*)localPlayer.Address;
+    }
+
+    private static unsafe Character* FindSubActor(Character* character, int subActorType)
+    {
+        if (character == null)
+            return null;
+
+        switch (subActorType)
+        {
+            case -1:
+                return character;
+            case 0:
+                return character->Mount.MountObject;
+            case 1:
+                var companion = character->Companion.CompanionObject;
+                if (companion == null)
+                    return null;
+                return &companion->Character;
+            case 2:
+                var ornament = character->Ornament.OrnamentObject;
+                if (ornament == null)
+                    return null;
+                return &ornament->Character;
+            default:
+                return null;
+        }
+    }
+
+    private static unsafe List<(int SubActorType, int ChildObjectIndex, int ModelSlot, int MaterialSlot)> FindMaterial(CharacterBase* drawObject, int subActorType, string materialPath)
+    {
+        static void CollectMaterials(List<(int, int, int, int)> result, int subActorType, int childObjectIndex, CharacterBase* drawObject, string materialPath)
+        {
+            for (var i = 0; i < drawObject->SlotCount; ++i)
+            {
+                var model = drawObject->Models[i];
+                if (model == null)
+                    continue;
+
+                for (var j = 0; j < model->MaterialCount; ++j)
+                {
+                    var material = model->Materials[j];
+                    if (material == null)
+                        continue;
+
+                    var mtrlHandle = material->MaterialResourceHandle;
+                    if (mtrlHandle == null)
+                        continue;
+
+                    var path = ResolveContext.GetResourceHandlePath((Structs.ResourceHandle*)mtrlHandle);
+                    if (path.ToString() == materialPath)
+                        result.Add((subActorType, childObjectIndex, i, j));
+                }
+            }
+        }
+
+        var result = new List<(int, int, int, int)>();
+
+        if (drawObject == null)
+            return result;
+
+        materialPath = materialPath.Replace('/', '\\').ToLowerInvariant();
+
+        CollectMaterials(result, subActorType, -1, drawObject, materialPath);
+
+        var firstChildObject = (CharacterBase*)drawObject->DrawObject.Object.ChildObject;
+        if (firstChildObject != null)
+        {
+            var childObject = firstChildObject;
+            var childObjectIndex = 0;
+            do
+            {
+                CollectMaterials(result, subActorType, childObjectIndex, childObject, materialPath);
+
+                childObject = (CharacterBase*)childObject->DrawObject.Object.NextSiblingObject;
+                ++childObjectIndex;
+            }
+            while (childObject != null && childObject != firstChildObject);
+        }
+
+        return result;
+    }
+
+    private static unsafe CharacterBase* GetChildObject(CharacterBase* drawObject, int index)
+    {
+        if (drawObject == null)
+            return null;
+
+        if (index >= 0)
+        {
+            drawObject = (CharacterBase*)drawObject->DrawObject.Object.ChildObject;
+            if (drawObject == null)
+                return null;
+        }
+
+        var first = drawObject;
+        while (index-- > 0)
+        {
+            drawObject = (CharacterBase*)drawObject->DrawObject.Object.NextSiblingObject;
+            if (drawObject == null || drawObject == first)
+                return null;
+        }
+
+        return drawObject;
+    }
+
+    private static unsafe Material* GetDrawObjectMaterial(CharacterBase* drawObject, int modelSlot, int materialSlot)
+    {
+        if (drawObject == null)
+            return null;
+
+        if (modelSlot < 0 || modelSlot >= drawObject->SlotCount)
+            return null;
+
+        var model = drawObject->Models[modelSlot];
+        if (model == null)
+            return null;
+
+        if (materialSlot < 0 || materialSlot >= model->MaterialCount)
+            return null;
+
+        return model->Materials[materialSlot];
+    }
+
+    private abstract unsafe class LiveMaterialPreviewerBase : IDisposable
+    {
+        private readonly IObjectTable _objects;
+
+        protected readonly int SubActorType;
+        protected readonly int ChildObjectIndex;
+        protected readonly int ModelSlot;
+        protected readonly int MaterialSlot;
+
+        protected readonly CharacterBase* DrawObject;
+        protected readonly Material*      Material;
+
+        protected bool Valid;
+
+        public LiveMaterialPreviewerBase(IObjectTable objects, int subActorType, int childObjectIndex, int modelSlot, int materialSlot)
+        {
+            _objects = objects;
+
+            SubActorType     = subActorType;
+            ChildObjectIndex = childObjectIndex;
+            ModelSlot        = modelSlot;
+            MaterialSlot     = materialSlot;
+
+            var localPlayer = FindLocalPlayer(objects);
+            if (localPlayer == null)
+                throw new InvalidOperationException("Cannot retrieve local player object");
+
+            var subActor = FindSubActor(localPlayer, subActorType);
+            if (subActor == null)
+                throw new InvalidOperationException("Cannot retrieve sub-actor (mount, companion or ornament)");
+
+            DrawObject = GetChildObject((CharacterBase*)subActor->GameObject.GetDrawObject(), childObjectIndex);
+            if (DrawObject == null)
+                throw new InvalidOperationException("Cannot retrieve draw object");
+
+            Material = GetDrawObjectMaterial(DrawObject, modelSlot, materialSlot);
+            if (Material == null)
+                throw new InvalidOperationException("Cannot retrieve material");
+
+            Valid = true;
+        }
+
+        ~LiveMaterialPreviewerBase()
+        {
+            if (Valid)
+                Dispose(false, IsStillValid());
+        }
+
+        public void Dispose()
+        {
+            if (Valid)
+                Dispose(true, IsStillValid());
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing, bool reset)
+        {
+            Valid = false;
+        }
+
+        public bool CheckValidity()
+        {
+            if (Valid && !IsStillValid())
+                Dispose(false, false);
+
+            return Valid;
+        }
+
+        protected virtual bool IsStillValid()
+        {
+            var localPlayer = FindLocalPlayer(_objects);
+            if (localPlayer == null)
+                return false;
+
+            var subActor = FindSubActor(localPlayer, SubActorType);
+            if (subActor == null)
+                return false;
+
+            if (DrawObject != GetChildObject((CharacterBase*)subActor->GameObject.GetDrawObject(), ChildObjectIndex))
+                return false;
+
+            if (Material != GetDrawObjectMaterial(DrawObject, ModelSlot, MaterialSlot))
+                return false;
+
+            return true;
+        }
+    }
+
+    private sealed unsafe class LiveMaterialPreviewer : LiveMaterialPreviewerBase
+    {
+        private readonly ShaderPackage* _shaderPackage;
+
+        private readonly uint    _originalShPkFlags;
+        private readonly float[] _originalMaterialParameter;
+        private readonly uint[]  _originalSamplerFlags;
+
+        public LiveMaterialPreviewer(IObjectTable objects, int subActorType, int childObjectIndex, int modelSlot, int materialSlot) : base(objects, subActorType, childObjectIndex, modelSlot, materialSlot)
+        {
+            var mtrlHandle = Material->MaterialResourceHandle;
+            if (mtrlHandle == null)
+                throw new InvalidOperationException("Material doesn't have a resource handle");
+
+            var shpkHandle = ((Structs.MtrlResource*)mtrlHandle)->ShpkResourceHandle;
+            if (shpkHandle == null)
+                throw new InvalidOperationException("Material doesn't have a ShPk resource handle");
+
+            _shaderPackage = shpkHandle->ShaderPackage;
+            if (_shaderPackage == null)
+                throw new InvalidOperationException("Material doesn't have a shader package");
+
+            var material = (Structs.Material*)Material;
+
+            _originalShPkFlags = material->ShaderPackageFlags;
+
+            if (material->MaterialParameter->TryGetBuffer(out var materialParameter))
+                _originalMaterialParameter = materialParameter.ToArray();
+            else
+                _originalMaterialParameter = Array.Empty<float>();
+
+            _originalSamplerFlags = new uint[material->TextureCount];
+            for (var i = 0; i < _originalSamplerFlags.Length; ++i)
+                _originalSamplerFlags[i] = material->Textures[i].SamplerFlags;
+        }
+
+        protected override void Dispose(bool disposing, bool reset)
+        {
+            base.Dispose(disposing, reset);
+
+            if (reset)
+            {
+                var material = (Structs.Material*)Material;
+
+                material->ShaderPackageFlags = _originalShPkFlags;
+
+                if (material->MaterialParameter->TryGetBuffer(out var materialParameter))
+                    _originalMaterialParameter.AsSpan().CopyTo(materialParameter);
+
+                for (var i = 0; i < _originalSamplerFlags.Length; ++i)
+                    material->Textures[i].SamplerFlags = _originalSamplerFlags[i];
+            }
+        }
+
+        public void SetShaderPackageFlags(uint shPkFlags)
+        {
+            if (!CheckValidity())
+                return;
+
+            ((Structs.Material*)Material)->ShaderPackageFlags = shPkFlags;
+        }
+
+        public void SetMaterialParameter(uint parameterCrc, Index offset, Span<float> value)
+        {
+            if (!CheckValidity())
+                return;
+
+            var cbuffer = ((Structs.Material*)Material)->MaterialParameter;
+            if (cbuffer == null)
+                return;
+
+            if (!cbuffer->TryGetBuffer(out var buffer))
+                return;
+
+            for (var i = 0; i < _shaderPackage->MaterialElementCount; ++i)
+            {
+                ref var parameter = ref _shaderPackage->MaterialElements[i];
+                if (parameter.CRC == parameterCrc)
+                {
+                    if ((parameter.Offset & 0x3) != 0 || (parameter.Size & 0x3) != 0 || (parameter.Offset + parameter.Size) >> 2 > buffer.Length)
+                        return;
+
+                    value.TryCopyTo(buffer.Slice(parameter.Offset >> 2, parameter.Size >> 2)[offset..]);
+                    return;
+                }
+            }
+        }
+
+        public void SetSamplerFlags(uint samplerCrc, uint samplerFlags)
+        {
+            if (!CheckValidity())
+                return;
+
+            var id = 0u;
+            var found = false;
+
+            var samplers = (Structs.ShaderPackageUtility.Sampler*)_shaderPackage->Samplers;
+            for (var i = 0; i < _shaderPackage->SamplerCount; ++i)
+            {
+                if (samplers[i].Crc == samplerCrc)
+                {
+                    id = samplers[i].Id;
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+                return;
+
+            var material = (Structs.Material*)Material;
+            for (var i = 0; i < material->TextureCount; ++i)
+            {
+                if (material->Textures[i].Id == id)
+                {
+                    material->Textures[i].SamplerFlags = (samplerFlags & 0xFFFFFDFF) | 0x000001C0;
+                    break;
+                }
+            }
+        }
+
+        protected override bool IsStillValid()
+        {
+            if (!base.IsStillValid())
+                return false;
+
+            var mtrlHandle = Material->MaterialResourceHandle;
+            if (mtrlHandle == null)
+                return false;
+
+            var shpkHandle = ((Structs.MtrlResource*)mtrlHandle)->ShpkResourceHandle;
+            if (shpkHandle == null)
+                return false;
+
+            if (_shaderPackage != shpkHandle->ShaderPackage)
+                return false;
+
+            return true;
+        }
+    }
+
+    private sealed unsafe class LiveColorSetPreviewer : LiveMaterialPreviewerBase
+    {
+        public const int TextureWidth  = 4;
+        public const int TextureHeight = MtrlFile.ColorSet.RowArray.NumRows;
+        public const int TextureLength = TextureWidth * TextureHeight * 4;
+
+        private readonly Framework _framework;
+
+        private readonly Texture** _colorSetTexture;
+        private readonly Texture*  _originalColorSetTexture;
+
+        private Half[] _colorSet;
+        private bool   _updatePending;
+
+        public Half[] ColorSet => _colorSet;
+
+        public LiveColorSetPreviewer(IObjectTable objects, Framework framework, int subActorType, int childObjectIndex, int modelSlot, int materialSlot) : base(objects, subActorType, childObjectIndex, modelSlot, materialSlot)
+        {
+            _framework = framework;
+
+            var mtrlHandle = Material->MaterialResourceHandle;
+            if (mtrlHandle == null)
+                throw new InvalidOperationException("Material doesn't have a resource handle");
+
+            var colorSetTextures = *(Texture***)((nint)DrawObject + 0x258);
+            if (colorSetTextures == null)
+                throw new InvalidOperationException("Draw object doesn't have color set textures");
+
+            _colorSetTexture = colorSetTextures + (modelSlot * 4 + materialSlot);
+
+            _originalColorSetTexture = *_colorSetTexture;
+            if (_originalColorSetTexture == null)
+                throw new InvalidOperationException("Material doesn't have a color set");
+            Structs.TextureUtility.IncRef(_originalColorSetTexture);
+
+            _colorSet = new Half[TextureLength];
+            _updatePending = true;
+
+            framework.Update += OnFrameworkUpdate;
+        }
+
+        protected override void Dispose(bool disposing, bool reset)
+        {
+            _framework.Update -= OnFrameworkUpdate;
+
+            base.Dispose(disposing, reset);
+
+            if (reset)
+            {
+                var oldTexture = (Texture*)Interlocked.Exchange(ref *(nint*)_colorSetTexture, (nint)_originalColorSetTexture);
+                Structs.TextureUtility.DecRef(oldTexture);
+            }
+            else
+                Structs.TextureUtility.DecRef(_originalColorSetTexture);
+        }
+
+        public void ScheduleUpdate()
+        {
+            _updatePending = true;
+        }
+
+        private void OnFrameworkUpdate(Framework _)
+        {
+            if (!_updatePending)
+                return;
+            _updatePending = false;
+
+            if (!CheckValidity())
+                return;
+
+            var textureSize = stackalloc int[2];
+            textureSize[0] = TextureWidth;
+            textureSize[1] = TextureHeight;
+
+            var newTexture = Structs.TextureUtility.Create2D(Device.Instance(), textureSize, 1, 0x2460, 0x80000804, 7);
+            if (newTexture == null)
+                return;
+
+            bool success;
+            lock (_colorSet)
+                fixed (Half* colorSet = _colorSet)
+                    success = Structs.TextureUtility.InitializeContents(newTexture, colorSet);
+
+            if (success)
+            {
+                var oldTexture = (Texture*)Interlocked.Exchange(ref *(nint*)_colorSetTexture, (nint)newTexture);
+                Structs.TextureUtility.DecRef(oldTexture);
+            }
+            else
+                Structs.TextureUtility.DecRef(newTexture);
+        }
+
+        protected override bool IsStillValid()
+        {
+            if (!base.IsStillValid())
+                return false;
+
+            var colorSetTextures = *(Texture***)((nint)DrawObject + 0x258);
+            if (colorSetTextures == null)
+                return false;
+
+            if (_colorSetTexture != colorSetTextures + (ModelSlot * 4 + MaterialSlot))
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.LivePreview.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.LivePreview.cs
@@ -154,7 +154,7 @@ public partial class ModEditWindow
         protected readonly int ModelSlot;
         protected readonly int MaterialSlot;
 
-        protected readonly CharacterBase* DrawObject;
+        public    readonly CharacterBase* DrawObject;
         protected readonly Material*      Material;
 
         protected bool Valid;

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.MtrlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.MtrlTab.cs
@@ -512,6 +512,29 @@ public partial class ModEditWindow
             ColorSetPreviewers.Clear();
         }
 
+        public unsafe void UnbindFromDrawObjectMaterialInstances(nint characterBase)
+        {
+            for (var i = MaterialPreviewers.Count; i-- > 0; )
+            {
+                var previewer = MaterialPreviewers[i];
+                if ((nint)previewer.DrawObject != characterBase)
+                    continue;
+
+                previewer.Dispose();
+                MaterialPreviewers.RemoveAt(i);
+            }
+
+            for (var i = ColorSetPreviewers.Count; i-- > 0;)
+            {
+                var previewer = ColorSetPreviewers[i];
+                if ((nint)previewer.DrawObject != characterBase)
+                    continue;
+
+                previewer.Dispose();
+                ColorSetPreviewers.RemoveAt(i);
+            }
+        }
+
         public void SetShaderPackageFlags(uint shPkFlags)
         {
             foreach (var previewer in MaterialPreviewers)
@@ -665,7 +688,10 @@ public partial class ModEditWindow
             AssociatedBaseDevkit = TryLoadShpkDevkit( "_base", out LoadedBaseDevkitPathName );
             LoadShpk( FindAssociatedShpk( out _, out _ ) );
             if (writable)
+            {
+                _edit._gameEvents.CharacterBaseDestructor += UnbindFromDrawObjectMaterialInstances;
                 BindToMaterialInstances();
+            }
         }
 
         ~MtrlTab()
@@ -682,6 +708,8 @@ public partial class ModEditWindow
         private void DoDispose()
         {
             UnbindFromMaterialInstances();
+            if (Writable)
+                _edit._gameEvents.CharacterBaseDestructor -= UnbindFromDrawObjectMaterialInstances;
         }
 
         public bool Valid

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.MtrlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.MtrlTab.cs
@@ -8,6 +8,7 @@ using Dalamud.Interface.Internal.Notifications;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 using ImGuiNET;
+using Newtonsoft.Json.Linq;
 using OtterGui;
 using OtterGui.Classes;
 using OtterGui.Raii;
@@ -16,6 +17,7 @@ using Penumbra.GameData.Data;
 using Penumbra.GameData.Files;
 using Penumbra.GameData.Structs;
 using Penumbra.Services;
+using Penumbra.String;
 using Penumbra.String.Classes;
 using Penumbra.Util;
 using static Penumbra.GameData.Files.ShpkFile;
@@ -26,49 +28,47 @@ public partial class ModEditWindow
 {
     private sealed class MtrlTab : IWritable, IDisposable
     {
+        private const int ShpkPrefixLength = 16;
+
+        private static readonly ByteString ShpkPrefix = ByteString.FromSpanUnsafe("shader/sm5/shpk/"u8, true, true, true);
+
         private readonly ModEditWindow _edit;
         public readonly  MtrlFile      Mtrl;
         public readonly  string        FilePath;
         public readonly  bool          Writable;
 
-        public uint NewKeyId;
-        public uint NewKeyDefault;
-        public uint NewConstantId;
-        public int  NewConstantIdx;
-        public uint NewSamplerId;
-        public int  NewSamplerIdx;
+        private string[]? _shpkNames;
 
+        public string    ShaderHeader             = "Shader###Shader";
+        public FullPath  LoadedShpkPath           = FullPath.Empty;
+        public string    LoadedShpkPathName       = string.Empty;
+        public string    LoadedShpkDevkitPathName = string.Empty;
+        public string    ShaderComment            = string.Empty;
+        public ShpkFile? AssociatedShpk;
+        public JObject?  AssociatedShpkDevkit;
 
-        public          ShpkFile?      AssociatedShpk;
-        public readonly List< string > TextureLabels      = new(4);
-        public          FullPath       LoadedShpkPath     = FullPath.Empty;
-        public          string         LoadedShpkPathName = string.Empty;
-        public          float          TextureLabelWidth;
+        public readonly string   LoadedBaseDevkitPathName = string.Empty;
+        public readonly JObject? AssociatedBaseDevkit;
 
         // Shader Key State
-        public readonly List< string >           ShaderKeyLabels         = new(16);
-        public readonly Dictionary< uint, uint > DefinedShaderKeys       = new(16);
-        public readonly List< int >              MissingShaderKeyIndices = new(16);
-        public readonly List< uint >             AvailableKeyValues      = new(16);
-        public          string                   VertexShaders           = "Vertex Shaders: ???";
-        public          string                   PixelShaders            = "Pixel Shaders: ???";
+        public readonly List< (string Label, int Index, string Description, bool MonoFont, IReadOnlyList< (string Label, uint Value, string Description) > Values) > ShaderKeys = new(16);
+
+        public readonly HashSet< int > VertexShaders       = new(16);
+        public readonly HashSet< int > PixelShaders        = new(16);
+        public          bool           ShadersKnown        = false;
+        public          string         VertexShadersString = "Vertex Shaders: ???";
+        public          string         PixelShadersString  = "Pixel Shaders: ???";
+
+        // Textures & Samplers
+        public readonly List< (string Label, int TextureIndex, int SamplerIndex, string Description, bool MonoFont) > Textures = new(4);
+
+        public readonly HashSet< int >  UnfoldedTextures   = new(4);
+        public readonly HashSet< uint > SamplerIds         = new(16);
+        public          float           TextureLabelWidth;
+        public          bool            UseColorDyeSet;
 
         // Material Constants
-        public readonly List< (string Name, bool ComponentOnly, int ParamValueOffset) > MaterialConstants        = new(16);
-        public readonly List< (string Name, uint Id, ushort ByteSize) >                 MissingMaterialConstants = new(16);
-        public readonly HashSet< uint >                                                 DefinedMaterialConstants = new(16);
-
-        public string   MaterialConstantLabel  = "Constants###Constants";
-        public IndexSet OrphanedMaterialValues = new(0, false);
-        public int      AliasedMaterialValueCount;
-        public bool     HasMalformedMaterialConstants;
-
-        // Samplers
-        public readonly List< (string Label, string FileName, uint Id) > Samplers         = new(4);
-        public readonly List< (string Name, uint Id) >                   MissingSamplers  = new(4);
-        public readonly HashSet< uint >                                  DefinedSamplers  = new(4);
-        public          IndexSet                                         OrphanedSamplers = new(0, false);
-        public          int                                              AliasedSamplerCount;
+        public readonly List< (string Header, List< (string Label, int ConstantIndex, Range Slice, string Description, bool MonoFont, IConstantEditor Editor) > Constants) > Constants = new(16);
 
         // Live-Previewers
         public readonly List<LiveMaterialPreviewer> MaterialPreviewers     = new(4);
@@ -87,8 +87,24 @@ public partial class ModEditWindow
             return _edit.FindBestMatch( defaultGamePath );
         }
 
+        public string[] GetShpkNames()
+        {
+            if (null != _shpkNames)
+                return _shpkNames;
+
+            var names = new HashSet<string>(StandardShaderPackages);
+            names.UnionWith(_edit.FindPathsStartingWith(ShpkPrefix).Select(path => path.ToString()[ShpkPrefixLength..]));
+
+            _shpkNames = names.ToArray();
+            Array.Sort(_shpkNames);
+
+            return _shpkNames;
+        }
+
         public void LoadShpk( FullPath path )
         {
+            ShaderHeader = $"Shader ({Mtrl.ShaderPackage.Name})###Shader";
+
             try
             {
                 LoadedShpkPath = path;
@@ -106,180 +122,314 @@ public partial class ModEditWindow
                 Penumbra.Chat.NotificationMessage( $"Could not load {LoadedShpkPath.ToPath()}:\n{e}", "Penumbra Advanced Editing", NotificationType.Error );
             }
 
+            if( LoadedShpkPath.InternalName.IsEmpty )
+            {
+                AssociatedShpkDevkit     = null;
+                LoadedShpkDevkitPathName = string.Empty;
+            }
+            else
+                AssociatedShpkDevkit = TryLoadShpkDevkit( Path.GetFileNameWithoutExtension( Mtrl.ShaderPackage.Name ), out LoadedShpkDevkitPathName );
+
+            UpdateShaderKeys();
             Update();
         }
 
-        public void UpdateTextureLabels()
+        private JObject? TryLoadShpkDevkit(string shpkBaseName, out string devkitPathName)
         {
-            var samplers = Mtrl.GetSamplersByTexture( AssociatedShpk );
-            TextureLabels.Clear();
-            TextureLabelWidth = 50f * UiHelpers.Scale;
-            using( var _ = ImRaii.PushFont( UiBuilder.MonoFont ) )
+            try
             {
-                for( var i = 0; i < Mtrl.Textures.Length; ++i )
-                {
-                    var (sampler, shpkSampler) = samplers[ i ];
-                    var name = shpkSampler.HasValue ? shpkSampler.Value.Name : sampler.HasValue ? $"0x{sampler.Value.SamplerId:X8}" : $"#{i}";
-                    TextureLabels.Add( name );
-                    TextureLabelWidth = Math.Max( TextureLabelWidth, ImGui.CalcTextSize( name ).X );
-                }
-            }
+                if (!Utf8GamePath.FromString("penumbra/shpk_devkit/" + shpkBaseName + ".json", out var devkitPath))
+                    throw new Exception("Could not assemble ShPk dev-kit path.");
 
-            TextureLabelWidth = TextureLabelWidth / UiHelpers.Scale + 4;
+                var devkitFullPath = _edit.FindBestMatch(devkitPath);
+                if (!devkitFullPath.IsRooted)
+                    throw new Exception("Could not resolve ShPk dev-kit path.");
+
+                devkitPathName = devkitFullPath.FullName;
+                return JObject.Parse(File.ReadAllText(devkitFullPath.FullName));
+            }
+            catch
+            {
+                devkitPathName = string.Empty;
+                return null;
+            }
         }
 
-        public void UpdateShaderKeyLabels()
+        private T? TryGetShpkDevkitData<T>(string category, uint? id, bool mayVary) where T : class
         {
-            ShaderKeyLabels.Clear();
-            DefinedShaderKeys.Clear();
-            foreach( var (key, idx) in Mtrl.ShaderPackage.ShaderKeys.WithIndex() )
-            {
-                ShaderKeyLabels.Add( $"#{idx}: 0x{key.Category:X8} = 0x{key.Value:X8}###{idx}: 0x{key.Category:X8}" );
-                DefinedShaderKeys.Add( key.Category, key.Value );
-            }
+            return TryGetShpkDevkitData<T>(AssociatedShpkDevkit, LoadedShpkDevkitPathName, category, id, mayVary)
+                ?? TryGetShpkDevkitData<T>(AssociatedBaseDevkit, LoadedBaseDevkitPathName, category, id, mayVary);
+        }
 
-            MissingShaderKeyIndices.Clear();
-            AvailableKeyValues.Clear();
-            var vertexShaders = new IndexSet( AssociatedShpk?.VertexShaders.Length ?? 0, false );
-            var pixelShaders  = new IndexSet( AssociatedShpk?.PixelShaders.Length  ?? 0, false );
-            if( AssociatedShpk != null )
-            {
-                MissingShaderKeyIndices.AddRange( AssociatedShpk.MaterialKeys.WithIndex().Where( k => !DefinedShaderKeys.ContainsKey( k.Value.Id ) ).WithoutValue() );
+        private T? TryGetShpkDevkitData<T>(JObject? devkit, string devkitPathName, string category, uint? id, bool mayVary) where T : class
+        {
+            if (devkit == null)
+                return null;
 
-                if( MissingShaderKeyIndices.Count > 0 && MissingShaderKeyIndices.All( i => AssociatedShpk.MaterialKeys[ i ].Id != NewKeyId ) )
+            try
+            {
+                var data = devkit[category];
+                if (id.HasValue)
+                    data = data?[id.Value.ToString()];
+
+                if (mayVary && (data as JObject)?["Vary"] != null)
                 {
-                    var key = AssociatedShpk.MaterialKeys[ MissingShaderKeyIndices[ 0 ] ];
-                    NewKeyId      = key.Id;
-                    NewKeyDefault = key.DefaultValue;
+                    var selector = BuildSelector(data!["Vary"]!
+                        .Select(key => (uint)key)
+                        .Select(key => Mtrl.GetShaderKey(key)?.Value ?? AssociatedShpk!.GetMaterialKeyById(key)!.Value.DefaultValue));
+                    var index = (int)data["Selectors"]![selector.ToString()]!;
+                    data = data["Items"]![index];
                 }
 
-                AvailableKeyValues.AddRange( AssociatedShpk.MaterialKeys.Select( k => DefinedShaderKeys.TryGetValue( k.Id, out var value ) ? value : k.DefaultValue ) );
-                foreach( var node in AssociatedShpk.Nodes )
+                return data?.ToObject(typeof(T)) as T;
+            }
+            catch (Exception e)
+            {
+                // Some element in the JSON was undefined or invalid (wrong type, key that doesn't exist in the ShPk, index out of range, …)
+                Penumbra.Log.Error($"Error while traversing the ShPk dev-kit file at {devkitPathName}: {e}");
+                return null;
+            }
+        }
+
+        public void UpdateShaderKeys()
+        {
+            ShaderKeys.Clear();
+            if (AssociatedShpk != null)
+            {
+                foreach (var key in AssociatedShpk.MaterialKeys)
                 {
-                    if( node.MaterialKeys.WithIndex().All( key => key.Value == AvailableKeyValues[ key.Index ] ) )
+                    var dkData = TryGetShpkDevkitData<DevkitShaderKey>("ShaderKeys", key.Id, false);
+                    var hasDkLabel = !string.IsNullOrEmpty(dkData?.Label);
+
+                    var valueSet = new HashSet<uint>(key.Values);
+                    if (dkData != null)
+                        valueSet.UnionWith(dkData.Values.Keys);
+
+                    var mtrlKeyIndex = Mtrl.FindOrAddShaderKey(key.Id, key.DefaultValue);
+                    var values = valueSet.Select<uint, (string Label, uint Value, string Description)>(value =>
                     {
-                        foreach( var pass in node.Passes )
+                        if (dkData != null && dkData.Values.TryGetValue(value, out var dkValue))
+                            return (dkValue.Label.Length > 0 ? dkValue.Label : $"0x{value:X8}", value, dkValue.Description);
+                        else
+                            return ($"0x{value:X8}", value, string.Empty);
+                    }).ToArray();
+                    Array.Sort(values, (x, y) =>
+                    {
+                        if (x.Value == key.DefaultValue)
+                            return -1;
+                        if (y.Value == key.DefaultValue)
+                            return 1;
+                        return x.Label.CompareTo(y.Label);
+                    });
+                    ShaderKeys.Add((hasDkLabel ? dkData!.Label : $"0x{key.Id:X8}", mtrlKeyIndex, dkData?.Description ?? string.Empty, !hasDkLabel, values));
+                }
+            }
+            else
+            {
+                foreach (var (key, index) in Mtrl.ShaderPackage.ShaderKeys.WithIndex())
+                    ShaderKeys.Add(($"0x{key.Category:X8}", index, string.Empty, true, Array.Empty<(string, uint, string)>()));
+            }
+        }
+
+        public void UpdateShaders()
+        {
+            VertexShaders.Clear();
+            PixelShaders.Clear();
+            if (AssociatedShpk == null)
+                ShadersKnown = false;
+            else
+            {
+                ShadersKnown = true;
+                var systemKeySelectors  = AllSelectors(AssociatedShpk.SystemKeys).ToArray();
+                var sceneKeySelectors   = AllSelectors(AssociatedShpk.SceneKeys).ToArray();
+                var subViewKeySelectors = AllSelectors(AssociatedShpk.SubViewKeys).ToArray();
+                var materialKeySelector = BuildSelector(AssociatedShpk.MaterialKeys.Select(key => Mtrl.GetOrAddShaderKey(key.Id, key.DefaultValue).Value));
+                foreach (var systemKeySelector in systemKeySelectors)
+                {
+                    foreach (var sceneKeySelector in sceneKeySelectors)
+                    {
+                        foreach (var subViewKeySelector in subViewKeySelectors)
                         {
-                            vertexShaders.Add( ( int )pass.VertexShader );
-                            pixelShaders.Add( ( int )pass.PixelShader );
+                            var selector = BuildSelector(systemKeySelector, sceneKeySelector, materialKeySelector, subViewKeySelector);
+                            var node = AssociatedShpk.GetNodeBySelector(selector);
+                            if (node.HasValue)
+                            {
+                                foreach (var pass in node.Value.Passes)
+                                {
+                                    VertexShaders.Add((int)pass.VertexShader);
+                                    PixelShaders.Add((int)pass.PixelShader);
+                                }
+                            }
+                            else
+                                ShadersKnown = false;
                         }
                     }
                 }
             }
 
-            VertexShaders = $"Vertex Shaders: {( vertexShaders.Count > 0 ? string.Join( ", ", vertexShaders.Select( i => $"#{i}" ) ) : "???" )}";
-            PixelShaders  = $"Pixel Shaders: {( pixelShaders.Count   > 0 ? string.Join( ", ", pixelShaders.Select( i => $"#{i}" ) ) : "???" )}";
+            var vertexShaders = VertexShaders.OrderBy(i => i).Select(i => $"#{i}");
+            var pixelShaders  = PixelShaders.OrderBy(i => i).Select(i => $"#{i}");
+
+            VertexShadersString = $"Vertex Shaders: {string.Join(", ", ShadersKnown ? vertexShaders : vertexShaders.Append("???"))}";
+            PixelShadersString  = $"Pixel Shaders: {string.Join(", ", ShadersKnown ? pixelShaders : pixelShaders.Append("???"))}";
+
+            ShaderComment = TryGetShpkDevkitData<string>("Comment", null, true) ?? string.Empty;
         }
 
-        public void UpdateConstantLabels()
+        public void UpdateTextures()
         {
-            var prefix = AssociatedShpk?.GetConstantById( MaterialParamsConstantId )?.Name ?? string.Empty;
-            MaterialConstantLabel = prefix.Length == 0 ? "Constants###Constants" : prefix + "###Constants";
-
-            DefinedMaterialConstants.Clear();
-            MaterialConstants.Clear();
-            HasMalformedMaterialConstants = false;
-            AliasedMaterialValueCount     = 0;
-            OrphanedMaterialValues        = new IndexSet( Mtrl.ShaderPackage.ShaderValues.Length, true );
-            foreach( var (constant, idx) in Mtrl.ShaderPackage.Constants.WithIndex() )
+            Textures.Clear();
+            SamplerIds.Clear();
+            if (AssociatedShpk == null)
             {
-                DefinedMaterialConstants.Add( constant.Id );
-                var values           = Mtrl.GetConstantValues( constant );
-                var paramValueOffset = -values.Length;
-                if( values.Length > 0 )
+                SamplerIds.UnionWith(Mtrl.ShaderPackage.Samplers.Select(sampler => sampler.SamplerId));
+                if (Mtrl.ColorSets.Any(c => c.HasRows))
+                    SamplerIds.Add(TableSamplerId);
+
+                foreach (var (sampler, index) in Mtrl.ShaderPackage.Samplers.WithIndex())
+                    Textures.Add(($"0x{sampler.SamplerId:X8}", sampler.TextureIndex, index, string.Empty, true));
+            }
+            else
+            {
+                foreach (var index in VertexShaders)
+                    SamplerIds.UnionWith(AssociatedShpk.VertexShaders[index].Samplers.Select(sampler => sampler.Id));
+                foreach (var index in PixelShaders)
+                    SamplerIds.UnionWith(AssociatedShpk.PixelShaders[index].Samplers.Select(sampler => sampler.Id));
+                if (!ShadersKnown)
                 {
-                    var shpkParam       = AssociatedShpk?.GetMaterialParamById( constant.Id );
-                    var paramByteOffset = shpkParam?.ByteOffset ?? -1;
-                    if( ( paramByteOffset & 0x3 ) == 0 )
-                    {
-                        paramValueOffset = paramByteOffset >> 2;
-                    }
-
-                    var unique = OrphanedMaterialValues.RemoveRange( constant.ByteOffset >> 2, values.Length );
-                    AliasedMaterialValueCount += values.Length - unique;
+                    SamplerIds.UnionWith(Mtrl.ShaderPackage.Samplers.Select(sampler => sampler.SamplerId));
+                    if (Mtrl.ColorSets.Any(c => c.HasRows))
+                        SamplerIds.Add(TableSamplerId);
                 }
-                else
+                foreach (var samplerId in SamplerIds)
                 {
-                    HasMalformedMaterialConstants = true;
+                    var shpkSampler = AssociatedShpk.GetSamplerById(samplerId);
+                    if (!shpkSampler.HasValue || shpkSampler.Value.Slot != 2)
+                        continue;
+
+                    var dkData = TryGetShpkDevkitData<DevkitSampler>("Samplers", samplerId, true);
+                    var hasDkLabel = !string.IsNullOrEmpty(dkData?.Label);
+
+                    var sampler = Mtrl.GetOrAddSampler(samplerId, dkData?.DefaultTexture ?? string.Empty, out var samplerIndex);
+                    Textures.Add((hasDkLabel ? dkData!.Label : shpkSampler.Value.Name, sampler.TextureIndex, samplerIndex, dkData?.Description ?? string.Empty, !hasDkLabel));
                 }
+                if (SamplerIds.Contains(TableSamplerId))
+                    Mtrl.FindOrAddColorSet();
+            }
+            Textures.Sort((x, y) => string.CompareOrdinal(x.Label, y.Label));
 
-                var (name, componentOnly) = MaterialParamRangeName( prefix, paramValueOffset, values.Length );
-                var label = name == null
-                    ? $"#{idx:D2} (ID: 0x{constant.Id:X8})###{constant.Id}"
-                    : $"#{idx:D2}: {name} (ID: 0x{constant.Id:X8})###{constant.Id}";
+            TextureLabelWidth = 50f * UiHelpers.Scale;
 
-                MaterialConstants.Add( ( label, componentOnly, paramValueOffset ) );
+            float helpWidth;
+            using (var _ = ImRaii.PushFont(UiBuilder.IconFont))
+                helpWidth = ImGui.GetStyle().ItemSpacing.X + ImGui.CalcTextSize(FontAwesomeIcon.InfoCircle.ToIconString()).X;
+
+            foreach (var (label, _, _, description, monoFont) in Textures)
+                if (!monoFont)
+                    TextureLabelWidth = Math.Max(TextureLabelWidth, ImGui.CalcTextSize(label).X + (description.Length > 0 ? helpWidth : 0.0f));
+
+            using (var _ = ImRaii.PushFont(UiBuilder.MonoFont))
+            {
+                foreach (var (label, _, _, description, monoFont) in Textures)
+                    if (monoFont)
+                        TextureLabelWidth = Math.Max(TextureLabelWidth, ImGui.CalcTextSize(label).X + (description.Length > 0 ? helpWidth : 0.0f));
             }
 
-            MissingMaterialConstants.Clear();
-            if( AssociatedShpk != null )
-            {
-                var setIdx = false;
-                foreach( var param in AssociatedShpk.MaterialParams.Where( m => !DefinedMaterialConstants.Contains( m.Id ) ) )
-                {
-                    var (name, _) = MaterialParamRangeName( prefix, param.ByteOffset >> 2, param.ByteSize >> 2 );
-                    var label = name == null
-                        ? $"(ID: 0x{param.Id:X8})"
-                        : $"{name} (ID: 0x{param.Id:X8})";
-                    if( NewConstantId == param.Id )
-                    {
-                        setIdx         = true;
-                        NewConstantIdx = MissingMaterialConstants.Count;
-                    }
-
-                    MissingMaterialConstants.Add( ( label, param.Id, param.ByteSize ) );
-                }
-
-                if( !setIdx && MissingMaterialConstants.Count > 0 )
-                {
-                    NewConstantIdx = 0;
-                    NewConstantId  = MissingMaterialConstants[ 0 ].Id;
-                }
-            }
+            TextureLabelWidth = TextureLabelWidth / UiHelpers.Scale + 4;
         }
 
-        public void UpdateSamplers()
+        public void UpdateConstants()
         {
-            Samplers.Clear();
-            DefinedSamplers.Clear();
-            OrphanedSamplers = new IndexSet( Mtrl.Textures.Length, true );
-            foreach( var (sampler, idx) in Mtrl.ShaderPackage.Samplers.WithIndex() )
+            static List<T> FindOrAddGroup<T>(List<(string, List<T>)> groups, string name)
             {
-                DefinedSamplers.Add( sampler.SamplerId );
-                if( !OrphanedSamplers.Remove( sampler.TextureIndex ) )
-                {
-                    ++AliasedSamplerCount;
-                }
+                foreach (var (groupName, group) in groups)
+                    if (string.Equals(name, groupName, StringComparison.Ordinal))
+                        return group;
 
-                var shpk = AssociatedShpk?.GetSamplerById( sampler.SamplerId );
-                var label = shpk.HasValue
-                    ? $"#{idx}: {shpk.Value.Name} (ID: 0x{sampler.SamplerId:X8})##{sampler.SamplerId}"
-                    : $"#{idx} (ID: 0x{sampler.SamplerId:X8})##{sampler.SamplerId}";
-                var fileName = $"Texture #{sampler.TextureIndex} - {Path.GetFileName( Mtrl.Textures[ sampler.TextureIndex ].Path )}";
-                Samplers.Add( ( label, fileName, sampler.SamplerId ) );
+                var newGroup = new List<T>(16);
+                groups.Add((name, newGroup));
+                return newGroup;
             }
 
-            MissingSamplers.Clear();
-            if( AssociatedShpk != null )
+            Constants.Clear();
+            if (AssociatedShpk == null)
             {
-                var setSampler = false;
-                foreach( var sampler in AssociatedShpk.Samplers.Where( s => s.Slot == 2 && !DefinedSamplers.Contains( s.Id ) ) )
+                var fcGroup = FindOrAddGroup(Constants, "Further Constants");
+                foreach (var (constant, index) in Mtrl.ShaderPackage.Constants.WithIndex())
                 {
-                    if( sampler.Id == NewSamplerId )
+                    var values = Mtrl.GetConstantValues(constant);
+                    for (var i = 0; i < values.Length; i += 4)
+                        fcGroup.Add(($"0x{constant.Id:X8}", index, i..Math.Min(i + 4, values.Length), string.Empty, true, FloatConstantEditor.Default));
+                }
+            }
+            else
+            {
+                var prefix = AssociatedShpk.GetConstantById(MaterialParamsConstantId)?.Name ?? string.Empty;
+                foreach (var shpkConstant in AssociatedShpk.MaterialParams)
+                {
+                    if ((shpkConstant.ByteSize & 0x3) != 0)
+                        continue;
+
+                    var constant = Mtrl.GetOrAddConstant(shpkConstant.Id, shpkConstant.ByteSize >> 2, out var constantIndex);
+                    var values = Mtrl.GetConstantValues(constant);
+                    var handledElements = new IndexSet(values.Length, false);
+
+                    var dkData = TryGetShpkDevkitData<DevkitConstant[]>("Constants", shpkConstant.Id, true);
+                    if (dkData != null)
                     {
-                        setSampler    = true;
-                        NewSamplerIdx = MissingSamplers.Count;
+                        foreach (var dkConstant in dkData)
+                        {
+                            var offset = (int)dkConstant.Offset;
+                            var length = values.Length - offset;
+                            if (dkConstant.Length.HasValue)
+                                length = Math.Min(length, (int)dkConstant.Length.Value);
+                            if (length <= 0)
+                                continue;
+                            var editor = dkConstant.CreateEditor();
+                            if (editor != null)
+                                FindOrAddGroup(Constants, dkConstant.Group.Length > 0 ? dkConstant.Group : "Further Constants")
+                                    .Add((dkConstant.Label, constantIndex, offset..(offset + length), dkConstant.Description, false, editor));
+                            handledElements.AddRange(offset, length);
+                        }
                     }
 
-                    MissingSamplers.Add( ( sampler.Name, sampler.Id ) );
-                }
-
-                if( !setSampler && MissingSamplers.Count > 0 )
-                {
-                    NewSamplerIdx = 0;
-                    NewSamplerId  = MissingSamplers[ 0 ].Id;
+                    var fcGroup = FindOrAddGroup(Constants, "Further Constants");
+                    foreach (var (start, end) in handledElements.Ranges(true))
+                    {
+                        if ((shpkConstant.ByteOffset & 0x3) == 0)
+                        {
+                            var offset = shpkConstant.ByteOffset >> 2;
+                            for (int i = (start & ~0x3) - (offset & 0x3), j = offset >> 2; i < end; i += 4, ++j)
+                            {
+                                var rangeStart = Math.Max(i, start);
+                                var rangeEnd = Math.Min(i + 4, end);
+                                if (rangeEnd > rangeStart)
+                                    fcGroup.Add(($"{prefix}[{j:D2}]{VectorSwizzle((offset + rangeStart) & 0x3, (offset + rangeEnd - 1) & 0x3)} (0x{shpkConstant.Id:X8})", constantIndex, rangeStart..rangeEnd, string.Empty, true, FloatConstantEditor.Default));
+                            }
+                        }
+                        else
+                        {
+                            for (var i = start; i < end; i += 4)
+                                fcGroup.Add(($"0x{shpkConstant.Id:X8}", constantIndex, i..Math.Min(i + 4, end), string.Empty, true, FloatConstantEditor.Default));
+                        }
+                    }
                 }
             }
+
+            Constants.RemoveAll(group => group.Constants.Count == 0);
+            Constants.Sort((x, y) =>
+            {
+                if (string.Equals(x.Header, "Further Constants", StringComparison.Ordinal))
+                    return 1;
+                if (string.Equals(y.Header, "Further Constants", StringComparison.Ordinal))
+                    return -1;
+                return string.Compare(x.Header, y.Header, StringComparison.Ordinal);
+            });
+            // HACK the Replace makes w appear after xyz, for the cbuffer-location-based naming scheme
+            foreach (var (_, group) in Constants)
+                group.Sort((x, y) => string.CompareOrdinal(
+                    x.MonoFont ? x.Label.Replace("].w", "].{") : x.Label,
+                    y.MonoFont ? y.Label.Replace("].w", "].{") : y.Label));
         }
 
         public unsafe void BindToMaterialInstances()
@@ -329,6 +479,7 @@ public partial class ModEditWindow
                     // Carry on without that previewer.
                 }
             }
+            UpdateMaterialPreview();
 
             var colorSet = Mtrl.ColorSets.FirstOrNull(colorSet => colorSet.HasRows);
 
@@ -378,6 +529,19 @@ public partial class ModEditWindow
                 previewer.SetSamplerFlags(samplerCrc, samplerFlags);
         }
 
+        public void UpdateMaterialPreview()
+        {
+            SetShaderPackageFlags(Mtrl.ShaderPackage.Flags);
+            foreach (var constant in Mtrl.ShaderPackage.Constants)
+            {
+                var values = Mtrl.GetConstantValues(constant);
+                if (values != null)
+                    SetMaterialParameter(constant.Id, 0, values);
+            }
+            foreach (var sampler in Mtrl.ShaderPackage.Samplers)
+                SetSamplerFlags(sampler.SamplerId, sampler.Flags);
+        }
+
         public void HighlightColorSetRow(int rowIdx)
         {
             var oldRowIdx = HighlightedColorSetRow;
@@ -402,7 +566,7 @@ public partial class ModEditWindow
                 UpdateColorSetRowPreview(rowIdx);
         }
 
-        public unsafe void UpdateColorSetRowPreview(int rowIdx)
+        public void UpdateColorSetRowPreview(int rowIdx)
         {
             if (ColorSetPreviewers.Count == 0)
                 return;
@@ -415,12 +579,12 @@ public partial class ModEditWindow
             var maybeColorDyeSet = Mtrl.ColorDyeSets.FirstOrNull(colorDyeSet => colorDyeSet.Index == colorSet.Index);
 
             var row = colorSet.Rows[rowIdx];
-            if (maybeColorDyeSet.HasValue)
+            if (maybeColorDyeSet.HasValue && UseColorDyeSet)
             {
                 var stm = _edit._stainService.StmFile;
                 var dye = maybeColorDyeSet.Value.Rows[rowIdx];
                 if (stm.TryGetValue(dye.Template, (StainId)_edit._stainService.StainCombo.CurrentSelection.Key, out var dyes))
-                    ApplyDye(ref row, dye, dyes);
+                    row.ApplyDyeTemplate(dye, dyes);
             }
 
             if (HighlightedColorSetRow == rowIdx)
@@ -428,13 +592,12 @@ public partial class ModEditWindow
 
             foreach (var previewer in ColorSetPreviewers)
             {
-                fixed (Half* pDest = previewer.ColorSet)
-                    Buffer.MemoryCopy(&row, pDest + LiveColorSetPreviewer.TextureWidth * 4 * rowIdx, LiveColorSetPreviewer.TextureWidth * 4 * sizeof(Half), sizeof(MtrlFile.ColorSet.Row));
+                row.AsHalves().CopyTo(previewer.ColorSet.AsSpan().Slice(LiveColorSetPreviewer.TextureWidth * 4 * rowIdx, LiveColorSetPreviewer.TextureWidth * 4));
                 previewer.ScheduleUpdate();
             }
         }
 
-        public unsafe void UpdateColorSetPreview()
+        public void UpdateColorSetPreview()
         {
             if (ColorSetPreviewers.Count == 0)
                 return;
@@ -447,7 +610,7 @@ public partial class ModEditWindow
             var maybeColorDyeSet = Mtrl.ColorDyeSets.FirstOrNull(colorDyeSet => colorDyeSet.Index == colorSet.Index);
 
             var rows = colorSet.Rows;
-            if (maybeColorDyeSet.HasValue)
+            if (maybeColorDyeSet.HasValue && UseColorDyeSet)
             {
                 var stm = _edit._stainService.StmFile;
                 var stainId = (StainId)_edit._stainService.StainCombo.CurrentSelection.Key;
@@ -457,7 +620,7 @@ public partial class ModEditWindow
                     ref var row = ref rows[i];
                     var dye = colorDyeSet.Rows[i];
                     if (stm.TryGetValue(dye.Template, stainId, out var dyes))
-                        ApplyDye(ref row, dye, dyes);
+                        row.ApplyDyeTemplate(dye, dyes);
                 }
             }
 
@@ -466,24 +629,9 @@ public partial class ModEditWindow
 
             foreach (var previewer in ColorSetPreviewers)
             {
-                fixed (Half* pDest = previewer.ColorSet)
-                    Buffer.MemoryCopy(&rows, pDest, LiveColorSetPreviewer.TextureLength * sizeof(Half), sizeof(MtrlFile.ColorSet.RowArray));
+                rows.AsHalves().CopyTo(previewer.ColorSet);
                 previewer.ScheduleUpdate();
             }
-        }
-
-        private static void ApplyDye(ref MtrlFile.ColorSet.Row row, MtrlFile.ColorDyeSet.Row dye, StmFile.DyePack dyes)
-        {
-            if (dye.Diffuse)
-                row.Diffuse = dyes.Diffuse;
-            if (dye.Specular)
-                row.Specular = dyes.Specular;
-            if (dye.SpecularStrength)
-                row.SpecularStrength = dyes.SpecularPower;
-            if (dye.Emissive)
-                row.Emissive = dyes.Emissive;
-            if (dye.Gloss)
-                row.GlossStrength = dyes.Gloss;
         }
 
         private static void ApplyHighlight(ref MtrlFile.ColorSet.Row row, int time)
@@ -498,18 +646,19 @@ public partial class ModEditWindow
 
         public void Update()
         {
-            UpdateTextureLabels();
-            UpdateShaderKeyLabels();
-            UpdateConstantLabels();
-            UpdateSamplers();
+            UpdateShaders();
+            UpdateTextures();
+            UpdateConstants();
         }
 
         public MtrlTab( ModEditWindow edit, MtrlFile file, string filePath, bool writable )
         {
-            _edit    = edit;
-            Mtrl     = file;
-            FilePath = filePath;
-            Writable = writable;
+            _edit          = edit;
+            Mtrl           = file;
+            FilePath       = filePath;
+            Writable       = writable;
+            UseColorDyeSet = file.ColorDyeSets.Length > 0;
+            AssociatedBaseDevkit = TryLoadShpkDevkit( "_base", out LoadedBaseDevkitPathName );
             LoadShpk( FindAssociatedShpk( out _, out _ ) );
             if (writable)
                 BindToMaterialInstances();
@@ -532,9 +681,96 @@ public partial class ModEditWindow
         }
 
         public bool Valid
-            => Mtrl.Valid;
+            => ShadersKnown && Mtrl.Valid;
 
         public byte[] Write()
-            => Mtrl.Write();
+        {
+            var output = Mtrl.Clone();
+            output.GarbageCollect(AssociatedShpk, SamplerIds, UseColorDyeSet);
+
+            return output.Write();
+        }
+
+        private sealed class DevkitShaderKeyValue
+        {
+            public string Label       = string.Empty;
+            public string Description = string.Empty;
+        }
+
+        private sealed class DevkitShaderKey
+        {
+            public string                                 Label       = string.Empty;
+            public string                                 Description = string.Empty;
+            public Dictionary<uint, DevkitShaderKeyValue> Values      = new();
+        }
+
+        private sealed class DevkitSampler
+        {
+            public string Label          = string.Empty;
+            public string Description    = string.Empty;
+            public string DefaultTexture = string.Empty;
+        }
+
+        private enum DevkitConstantType
+        {
+            Hidden  = -1,
+            Float   = 0,
+            Integer = 1,
+            Color   = 2,
+            Enum    = 3,
+        }
+
+        private sealed class DevkitConstantValue
+        {
+            public string Label       = string.Empty;
+            public string Description = string.Empty;
+            public float  Value       = 0.0f;
+        }
+
+        private sealed class DevkitConstant
+        {
+            public uint               Offset      = 0;
+            public uint?              Length      = null;
+            public string             Group       = string.Empty;
+            public string             Label       = string.Empty;
+            public string             Description = string.Empty;
+            public DevkitConstantType Type        = DevkitConstantType.Float;
+
+            public float? Minimum       = null;
+            public float? Maximum       = null;
+            public float? Speed         = null;
+            public float  RelativeSpeed = 0.0f;
+            public float  Factor        = 1.0f;
+            public float  Bias          = 0.0f;
+            public byte   Precision     = 3;
+            public string Unit          = string.Empty;
+
+            public bool SquaredRgb = false;
+            public bool Clamped    = false;
+
+            public DevkitConstantValue[] Values = Array.Empty<DevkitConstantValue>();
+
+            public IConstantEditor? CreateEditor()
+            {
+                switch (Type)
+                {
+                    case DevkitConstantType.Hidden:
+                        return null;
+                    case DevkitConstantType.Float:
+                        return new FloatConstantEditor(Minimum, Maximum, Speed ?? 0.1f, RelativeSpeed, Factor, Bias, Precision, Unit);
+                    case DevkitConstantType.Integer:
+                        return new IntConstantEditor(ToInteger(Minimum), ToInteger(Maximum), Speed ?? 0.25f, RelativeSpeed, Factor, Bias, Unit);
+                    case DevkitConstantType.Color:
+                        return new ColorConstantEditor(SquaredRgb, Clamped);
+                    case DevkitConstantType.Enum:
+                        return new EnumConstantEditor(Array.ConvertAll(Values, value => (value.Label, value.Value, value.Description)));
+                    default:
+                        return FloatConstantEditor.Default;
+                }
+            }
+
+            private int? ToInteger(float? value)
+                => value.HasValue ? (int)Math.Clamp(MathF.Round(value.Value), int.MinValue, int.MaxValue) : null;
+        }
     }
 }

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.cs
@@ -15,13 +15,16 @@ public partial class ModEditWindow
 
     private bool DrawMaterialPanel( MtrlTab tab, bool disabled )
     {
+        DrawMaterialLivePreviewRebind( tab, disabled );
+
+        ImGui.Dummy( new Vector2( ImGui.GetTextLineHeight() / 2 ) );
         var ret = DrawMaterialTextureChange( tab, disabled );
 
         ImGui.Dummy( new Vector2( ImGui.GetTextLineHeight() / 2 ) );
-        ret |= DrawBackFaceAndTransparency( tab.Mtrl, disabled );
+        ret |= DrawBackFaceAndTransparency( tab, disabled );
 
         ImGui.Dummy( new Vector2( ImGui.GetTextLineHeight() / 2 ) );
-        ret |= DrawMaterialColorSetChange( tab.Mtrl, disabled );
+        ret |= DrawMaterialColorSetChange( tab, disabled );
 
         ImGui.Dummy( new Vector2( ImGui.GetTextLineHeight() / 2 ) );
         ret |= DrawMaterialShaderResources( tab, disabled );
@@ -30,6 +33,15 @@ public partial class ModEditWindow
         DrawOtherMaterialDetails( tab.Mtrl, disabled );
 
         return !disabled && ret;
+    }
+
+    private static void DrawMaterialLivePreviewRebind( MtrlTab tab, bool disabled )
+    {
+        if (disabled)
+            return;
+
+        if (ImGui.Button("Reload live-preview"))
+            tab.BindToMaterialInstances();
     }
 
     private static bool DrawMaterialTextureChange( MtrlTab tab, bool disabled )
@@ -62,7 +74,7 @@ public partial class ModEditWindow
         return ret;
     }
 
-    private static bool DrawBackFaceAndTransparency( MtrlFile file, bool disabled )
+    private static bool DrawBackFaceAndTransparency( MtrlTab tab, bool disabled )
     {
         const uint transparencyBit = 0x10;
         const uint backfaceBit     = 0x01;
@@ -71,19 +83,21 @@ public partial class ModEditWindow
 
         using var dis = ImRaii.Disabled( disabled );
 
-        var tmp = ( file.ShaderPackage.Flags & transparencyBit ) != 0;
+        var tmp = ( tab.Mtrl.ShaderPackage.Flags & transparencyBit ) != 0;
         if( ImGui.Checkbox( "Enable Transparency", ref tmp ) )
         {
-            file.ShaderPackage.Flags = tmp ? file.ShaderPackage.Flags | transparencyBit : file.ShaderPackage.Flags & ~transparencyBit;
-            ret                      = true;
+            tab.Mtrl.ShaderPackage.Flags = tmp ? tab.Mtrl.ShaderPackage.Flags | transparencyBit : tab.Mtrl.ShaderPackage.Flags & ~transparencyBit;
+            ret                          = true;
+            tab.SetShaderPackageFlags(tab.Mtrl.ShaderPackage.Flags);
         }
 
         ImGui.SameLine( 200 * UiHelpers.Scale + ImGui.GetStyle().ItemSpacing.X + ImGui.GetStyle().WindowPadding.X );
-        tmp = ( file.ShaderPackage.Flags & backfaceBit ) != 0;
+        tmp = ( tab.Mtrl.ShaderPackage.Flags & backfaceBit ) != 0;
         if( ImGui.Checkbox( "Hide Backfaces", ref tmp ) )
         {
-            file.ShaderPackage.Flags = tmp ? file.ShaderPackage.Flags | backfaceBit : file.ShaderPackage.Flags & ~backfaceBit;
-            ret                      = true;
+            tab.Mtrl.ShaderPackage.Flags = tmp ? tab.Mtrl.ShaderPackage.Flags | backfaceBit : tab.Mtrl.ShaderPackage.Flags & ~backfaceBit;
+            ret                          = true;
+            tab.SetShaderPackageFlags(tab.Mtrl.ShaderPackage.Flags);
         }
 
         return ret;

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.ShpkTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.ShpkTab.cs
@@ -27,8 +27,16 @@ public partial class ModEditWindow
         public ShpkTab(FileDialogService fileDialog, byte[] bytes)
         {
             FileDialog = fileDialog;
-            Shpk       = new ShpkFile(bytes, true);
-            Header     = $"Shader Package for DirectX {(int)Shpk.DirectXVersion}";
+            try
+            {
+                Shpk = new ShpkFile(bytes, true);
+            }
+            catch (NotImplementedException)
+            {
+                Shpk = new ShpkFile(bytes, false);
+            }
+
+            Header    = $"Shader Package for DirectX {(int)Shpk.DirectXVersion}";
             Extension = Shpk.DirectXVersion switch
             {
                 ShpkFile.DxVersion.DirectX9  => ".cso",

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -21,6 +23,7 @@ using Penumbra.Meta;
 using Penumbra.Mods;
 using Penumbra.Mods.Manager;
 using Penumbra.Services;
+using Penumbra.String;
 using Penumbra.String.Classes;
 using Penumbra.UI.Classes;
 using Penumbra.Util;
@@ -521,6 +524,23 @@ public partial class ModEditWindow : Window, IDisposable
             }
 
         return new FullPath(path);
+    }
+
+    private HashSet<Utf8GamePath> FindPathsStartingWith(ByteString prefix)
+    {
+        var ret = new HashSet<Utf8GamePath>();
+
+        foreach (var path in _activeCollections.Current.ResolvedFiles.Keys)
+            if (path.Path.StartsWith(prefix))
+                ret.Add(path);
+
+        if (_mod != null)
+            foreach (var option in _mod.Groups.SelectMany(g => g).Append(_mod.Default))
+                foreach (var path in option.Files.Keys)
+                    if (path.Path.StartsWith(prefix))
+                        ret.Add(path);
+
+        return ret;
     }
 
     public ModEditWindow(PerformanceTracker performance, FileDialogService fileDialog, ItemSwapTab itemSwapTab, IDataManager gameData,

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.cs
@@ -19,6 +19,7 @@ using Penumbra.GameData.Enums;
 using Penumbra.GameData.Files;
 using Penumbra.Import.Textures;
 using Penumbra.Interop.ResourceTree;
+using Penumbra.Interop.Services;
 using Penumbra.Meta;
 using Penumbra.Mods;
 using Penumbra.Mods.Manager;
@@ -45,6 +46,7 @@ public partial class ModEditWindow : Window, IDisposable
     private readonly ModMergeTab         _modMergeTab;
     private readonly CommunicatorService _communicator;
     private readonly IDragDropManager    _dragDropManager;
+    private readonly GameEventManager    _gameEvents;
 
     private Mod?    _mod;
     private Vector2 _iconSize = Vector2.Zero;
@@ -546,7 +548,7 @@ public partial class ModEditWindow : Window, IDisposable
     public ModEditWindow(PerformanceTracker performance, FileDialogService fileDialog, ItemSwapTab itemSwapTab, IDataManager gameData,
         Configuration config, ModEditor editor, ResourceTreeFactory resourceTreeFactory, MetaFileManager metaFileManager,
         StainService stainService, ActiveCollections activeCollections, DalamudServices dalamud, ModMergeTab modMergeTab,
-        CommunicatorService communicator, TextureManager textures, IDragDropManager dragDropManager)
+        CommunicatorService communicator, TextureManager textures, IDragDropManager dragDropManager, GameEventManager gameEvents)
         : base(WindowBaseLabel)
     {
         _performance       = performance;
@@ -562,6 +564,7 @@ public partial class ModEditWindow : Window, IDisposable
         _dragDropManager   = dragDropManager;
         _textures          = textures;
         _fileDialog        = fileDialog;
+        _gameEvents        = gameEvents;
         _materialTab = new FileEditor<MtrlTab>(this, gameData, config, _fileDialog, "Materials", ".mtrl",
             () => _editor.Files.Mtrl, DrawMaterialPanel, () => _mod?.ModPath.FullName ?? string.Empty,
             (bytes, path, writable) => new MtrlTab(this, new MtrlFile(bytes), path, writable));

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.cs
@@ -137,6 +137,9 @@ public partial class ModEditWindow : Window, IDisposable
     {
         _left.Dispose();
         _right.Dispose();
+        _materialTab.Reset();
+        _modelTab.Reset();
+        _shaderPackageTab.Reset();
     }
 
     public override void Draw()
@@ -541,12 +544,12 @@ public partial class ModEditWindow : Window, IDisposable
         _fileDialog        = fileDialog;
         _materialTab = new FileEditor<MtrlTab>(this, gameData, config, _fileDialog, "Materials", ".mtrl",
             () => _editor.Files.Mtrl, DrawMaterialPanel, () => _mod?.ModPath.FullName ?? string.Empty,
-            bytes => new MtrlTab(this, new MtrlFile(bytes)));
+            (bytes, path, writable) => new MtrlTab(this, new MtrlFile(bytes), path, writable));
         _modelTab = new FileEditor<MdlFile>(this, gameData, config, _fileDialog, "Models", ".mdl",
-            () => _editor.Files.Mdl, DrawModelPanel, () => _mod?.ModPath.FullName ?? string.Empty, bytes => new MdlFile(bytes));
+            () => _editor.Files.Mdl, DrawModelPanel, () => _mod?.ModPath.FullName ?? string.Empty, (bytes, _, _) => new MdlFile(bytes));
         _shaderPackageTab = new FileEditor<ShpkTab>(this, gameData, config, _fileDialog, "Shaders", ".shpk",
             () => _editor.Files.Shpk, DrawShaderPackagePanel, () => _mod?.ModPath.FullName ?? string.Empty,
-            bytes => new ShpkTab(_fileDialog, bytes));
+            (bytes, _, _) => new ShpkTab(_fileDialog, bytes));
         _center             = new CombinedTexture(_left, _right);
         _textureSelectCombo = new TextureDrawer.PathSelectCombo(textures, editor);
         _quickImportViewer  = new ResourceTreeViewer(_config, resourceTreeFactory, 2, OnQuickImportRefresh, DrawQuickImportActions);
@@ -557,6 +560,9 @@ public partial class ModEditWindow : Window, IDisposable
     {
         _communicator.ModPathChanged.Unsubscribe(OnModPathChanged);
         _editor?.Dispose();
+        _materialTab.Dispose();
+        _modelTab.Dispose();
+        _shaderPackageTab.Dispose();
         _left.Dispose();
         _right.Dispose();
         _center.Dispose();

--- a/Penumbra/UI/ModsTab/ModPanelSettingsTab.cs
+++ b/Penumbra/UI/ModsTab/ModPanelSettingsTab.cs
@@ -195,21 +195,7 @@ public class ModPanelSettingsTab : ITab
                         _collectionManager.Editor.SetModSetting(_collectionManager.Active.Current, _selector.Selected!, groupIdx, (uint)idx2);
 
                     if (option.Description.Length > 0)
-                    {
-                        var hovered = ImGui.IsItemHovered();
-                        ImGui.SameLine();
-                        using (var _ = ImRaii.PushFont(UiBuilder.IconFont))
-                        {
-                            using var color = ImRaii.PushColor(ImGuiCol.Text, ImGui.GetColorU32(ImGuiCol.TextDisabled));
-                            ImGuiUtil.RightAlign(FontAwesomeIcon.InfoCircle.ToIconString(), ImGui.GetStyle().ItemSpacing.X);
-                        }
-
-                        if (hovered)
-                        {
-                            using var tt = ImRaii.Tooltip();
-                            ImGui.TextUnformatted(option.Description);
-                        }
-                    }
+                        ImGuiUtil.SelectableHelpMarker(option.Description);
 
                     id.Pop();
                 }


### PR DESCRIPTION
See also https://github.com/Ottermandias/OtterGui/pull/3 and https://github.com/Ottermandias/Penumbra.GameData/pull/1.

# Shaders tab
- Add fail-safe mode if running on a platform that doesn't support disassembling shaders (some versions of Wine seem to support it, others not): still allow inspecting and editing the parts that don't require disassemblies, only disable the parts that do ;
- Rearrange some of the data from "Further Content" into new sections "Shader Resources" and "Shader Selection".

# Materials tab
## Color Sets
- Add a header, that is unfolded by default, but allows folding the entire section ;
- Improve color accuracy (see also https://github.com/chirpxiv/PalettePlus/commit/04e253629cc6d2cfc679bf3e5ad91f8b92b90e6b, https://github.com/imchillin/Anamnesis/pull/1322 – Different data structure, but still the same color encoding quirk) ;
- Add a "Dyeable" check box that turns a non-dyeable color set into a dyeable one and conversely ;
- Add a crosshair "button" that, on hover, attempts to make the corresponding row blink on your character, weapons, fashion accessory, minion and/or mount ;
- Make the Gloss Strength slider non-linear (by hand instead of using ImGui's logarithmic slider flag because it behaves badly when min and max are too far away) ;
- Make the Paste All Rows button disabled when the file is read-only ;
- Improve small things on most fields (bound checks, formatting, …) ;
- Remove the dye columns entirely when the color set is not dyeable ;
- Assume, for some purposes, that there is at most one color set with rows, as the client's structures do not allow for more ;
- See also "Live Preview" and "Shaders".

## Live Preview
- Add a live preview system on materials:
  - When opening a material file, it attempts to bind to instances of this file on the local player, including weapons, fashion accessory, minion and/or mount ;
  - Shader Flags (and the checkboxes for parts of this field) will be reflected in real time ;
  - Sampler Flags (and the new sub-fields for parts of this field) will be reflected in real time ;
  - Color Set will be reflected in real time – Selecting a preview dye will apply it on the live preview ;
  - Material Constants will be reflected in real time ;
  - Ending the editing session (by choosing another material, or closing the editor window) will revert the material to its state before the editing began ;
  - Making the changes permanent still requires a save and redraw/rezone/… ;
- ~~Known issue: it seems that, in some cases, ending the editing session after saving and redrawing can turn the material into some combination of the before and the after, stable but looking wrong – Redrawing/rezoning/… again fixes it for good.~~ (should be fixed by 5346abaadf34171d81a0525f16e44d1437eb2a9b)

## Samplers and Textures
- Add a header, that is unfolded by default, but allows folding the entire section ;
- Make the texture rows unfoldable: unfolding them will show the Texture and Sampler Flags ;
- Add a checkbox for the only useful bit of the Texture Flags (namely, the `--` prefix on DX11) ;
- Add clearer fields for the known useful bits of the Sampler Flags (UV Address Mode, LoD Bias, Min LoD) ;
- Give a default path to all added textures, that points to an actual vanilla texture, to avoid crashes due to path-less textures ;
- See also "Live Preview", "Shaders" and "Dev-Kit Files".

## Shaders
- Rearrange the fields into their own section ;
- Replace the Shader Package free text field by a list box:
  - The box gives choices that are pulled from the EXE ;
  - Some shader packages are hidden from this list because they cause issues, and they don't seem to be intended for use in materials ;
  - More choices will be dynamically pulled from the current collection and mod by looking at file redirections that start with `shader/sm5/shpk/` ;
- Rework the algorithm that determines which shaders are actually gonna be used depending on shader keys: the new algorithm gives an authoritative result ;
- Treat the material as invalid if the shaders cannot be determined for sure (which indicate a combination of shader keys that can result in game crashes) ;
- Automatically add and remove color set, sampler/texture pairs, shader keys and material constants depending on the needs of the selected shaders – Consequently, the buttons to add and remove them by hand have been removed, thereby preventing crashes due to missing samplers for the selected shader ;
- See also "Dev-Kit Files".

## Material Constants
- Rearrange the fields into their own section ;
- Add various editor components that can display and edit constants in several ways (floats, integers, colors, enums) ;
- See also "Live Preview", "Shaders" and "Dev-Kit Files".

## Dev-Kit Files
- Add a system where JSON files can be installed to provide editing context:
  - Example: [MDK.zip](https://github.com/xivdev/Penumbra/files/12433810/MDK.zip) – This is a PMP, GitHub doesn't allow non-well-known extensions ;
  - Two paths will be looked up: `penumbra/shpk_devkit/{ShPk name}.json` (for example, for `character.shpk`, `…/character.json`) and `penumbra/shpk_devkit/_base.json` ;
  - These files can provide user-friendly labels and :information_source: tooltips for shader keys (and their values), textures/samplers, constants (and their values, in the case of enums) ;
  - They can provide a shader comment that will be displayed below the list of selected shaders, for example to explain what the shader set is usually for, or its vertex paint semantics ;
  - They can provide more sensible default texture paths for specific samplers ;
  - They can provide configuration for constants (slices, show/hide, type, editor component settings, enum values) ;
  - They can group related constants together ;
  - If both files exist and contain data about the same element, the ShPk-specific one takes precedence ;
  - All the data elements (except the shader keys themselves) have access to the shader key values, to be able to provide better shader-specific context (for example, in `skin.shpk`, lip-specific constants are only relevant for the face shaders).