### PR TITLE
Add a few texture manipulation tools

### DIFF
--- a/Penumbra/Import/Textures/CombinedTexture.cs
+++ b/Penumbra/Import/Textures/CombinedTexture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Numerics;
 using System.Threading.Tasks;
 
@@ -68,6 +69,38 @@ public partial class CombinedTexture : IDisposable
             _current.TextureWrap!.Height);
     }
 
+    public void SaveAs(TextureType? texType, TextureManager textures, string path, TextureSaveType type, bool mipMaps)
+    {
+        TextureType finalTexType;
+        if (texType.HasValue)
+            finalTexType = texType.Value;
+        else
+        {
+            finalTexType = Path.GetExtension(path).ToLowerInvariant() switch
+            {
+                ".tex" => TextureType.Tex,
+                ".dds" => TextureType.Dds,
+                ".png" => TextureType.Png,
+                _      => TextureType.Unknown,
+            };
+        }
+
+        switch (finalTexType)
+        {
+            case TextureType.Tex:
+                SaveAsTex(textures, path, type, mipMaps);
+                break;
+            case TextureType.Dds:
+                SaveAsDds(textures, path, type, mipMaps);
+                break;
+            case TextureType.Png:
+                SaveAsPng(textures, path);
+                break;
+            default:
+                throw new ArgumentException($"Cannot save texture as TextureType {finalTexType} with extension {Path.GetExtension(path).ToLowerInvariant()}");
+        }
+    }
+
     public void SaveAsTex(TextureManager textures, string path, TextureSaveType type, bool mipMaps)
         => SaveAs(textures, path, type, mipMaps, true);
 
@@ -97,36 +130,22 @@ public partial class CombinedTexture : IDisposable
     public void Update()
     {
         Clean();
-        if (_left.IsLoaded)
+        switch (GetActualCombineOp())
         {
-            if (_right.IsLoaded)
-            {
-                _current = _centerStorage;
-                _mode    = Mode.Custom;
-            }
-            else if (!_invertLeft && _multiplierLeft.IsIdentity)
-            {
+            case CombineOp.Invalid:
+                break;
+            case CombineOp.LeftCopy:
                 _mode    = Mode.LeftCopy;
                 _current = _left;
-            }
-            else
-            {
-                _current = _centerStorage;
-                _mode    = Mode.Custom;
-            }
-        }
-        else if (_right.IsLoaded)
-        {
-            if (!_invertRight && _multiplierRight.IsIdentity)
-            {
-                _current = _right;
+                break;
+            case CombineOp.RightCopy:
                 _mode    = Mode.RightCopy;
-            }
-            else
-            {
-                _current = _centerStorage;
+                _current = _right;
+                break;
+            default:
                 _mode    = Mode.Custom;
-            }
+                _current = _centerStorage;
+                break;
         }
     }
 

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Textures.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Textures.cs
@@ -90,7 +90,7 @@ public partial class ModEditWindow
             if (ImGui.Selectable(newText, idx == _currentSaveAs))
                 _currentSaveAs = idx;
 
-            ImGuiUtil.HoverTooltip(newDesc);
+            ImGuiUtil.SelectableHelpMarker(newDesc);
         }
     }
 
@@ -114,73 +114,65 @@ public partial class ModEditWindow
             SaveAsCombo();
             ImGui.SameLine();
             MipMapInput();
-            if (ImGui.Button("Save as TEX", -Vector2.UnitX))
+
+            var canSaveInPlace = Path.IsPathRooted(_left.Path) && _left.Type is TextureType.Tex or TextureType.Dds or TextureType.Png;
+
+            var buttonSize2 = new Vector2((ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X) / 2, 0);
+            if (ImGuiUtil.DrawDisabledButton("Save in place", buttonSize2,
+                    "This saves the texture in place. This is not revertible.",
+                    !canSaveInPlace || _center.IsLeftCopy && _currentSaveAs == (int)CombinedTexture.TextureSaveType.AsIs))
             {
-                var fileName = Path.GetFileNameWithoutExtension(_left.Path.Length > 0 ? _left.Path : _right.Path);
-                _fileDialog.OpenSavePicker("Save Texture as TEX...", ".tex", fileName, ".tex", (a, b) =>
-                {
-                    if (a)
-                        _center.SaveAsTex(_textures, b, (CombinedTexture.TextureSaveType)_currentSaveAs, _addMipMaps);
-                }, _mod!.ModPath.FullName, _forceTextureStartPath);
-                _forceTextureStartPath = false;
+                _center.SaveAs(_left.Type, _textures, _left.Path, (CombinedTexture.TextureSaveType)_currentSaveAs, _addMipMaps);
+                AddReloadTask(_left.Path, false);
             }
 
-            if (ImGui.Button("Save as DDS", -Vector2.UnitX))
+            ImGui.SameLine();
+            if (ImGui.Button("Save as TEX, DDS or PNG", buttonSize2))
             {
-                var fileName = Path.GetFileNameWithoutExtension(_right.Path.Length > 0 ? _right.Path : _left.Path);
-                _fileDialog.OpenSavePicker("Save Texture as DDS...", ".dds", fileName, ".dds", (a, b) =>
+                var fileName = Path.GetFileNameWithoutExtension(_left.Path.Length > 0 ? _left.Path : _right.Path);
+                _fileDialog.OpenSavePicker("Save Texture as TEX, DDS or PNG...", "Textures{.png,.dds,.tex},.tex,.dds,.png", fileName, ".tex", (a, b) =>
                 {
                     if (a)
-                        _center.SaveAsDds(_textures, b, (CombinedTexture.TextureSaveType)_currentSaveAs, _addMipMaps);
+                    {
+                        _center.SaveAs(null, _textures, b, (CombinedTexture.TextureSaveType)_currentSaveAs, _addMipMaps);
+                        if (b == _left.Path)
+                            AddReloadTask(_left.Path, false);
+                        else if (b == _right.Path)
+                            AddReloadTask(_right.Path, true);
+                    }
                 }, _mod!.ModPath.FullName, _forceTextureStartPath);
                 _forceTextureStartPath = false;
             }
 
             ImGui.NewLine();
 
-            if (ImGui.Button("Save as PNG", -Vector2.UnitX))
+            var canConvertInPlace = canSaveInPlace && _left.Type is TextureType.Tex && _center.IsLeftCopy;
+
+            var buttonSize3 = new Vector2((ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X * 2) / 3, 0);
+            if (ImGuiUtil.DrawDisabledButton("Convert to BC7", buttonSize3,
+                    "This converts the texture to BC7 format in place. This is not revertible.",
+                    !canConvertInPlace || _left.Format is DXGIFormat.BC7Typeless or DXGIFormat.BC7UNorm or DXGIFormat.BC7UNormSRGB))
             {
-                var fileName = Path.GetFileNameWithoutExtension(_right.Path.Length > 0 ? _right.Path : _left.Path);
-                _fileDialog.OpenSavePicker("Save Texture as PNG...", ".png", fileName, ".png", (a, b) =>
-                {
-                    if (a)
-                        _center.SaveAsPng(_textures, b);
-                }, _mod!.ModPath.FullName, _forceTextureStartPath);
-                _forceTextureStartPath = false;
+                _center.SaveAsTex(_textures, _left.Path, CombinedTexture.TextureSaveType.BC7, _left.MipMaps > 1);
+                AddReloadTask(_left.Path, false);
             }
 
-            if (_left.Type is TextureType.Tex && _center.IsLeftCopy)
+            ImGui.SameLine();
+            if (ImGuiUtil.DrawDisabledButton("Convert to BC3", buttonSize3,
+                    "This converts the texture to BC3 format in place. This is not revertible.",
+                    !canConvertInPlace || _left.Format is DXGIFormat.BC3Typeless or DXGIFormat.BC3UNorm or DXGIFormat.BC3UNormSRGB))
             {
-                var buttonSize = new Vector2((ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X * 2) / 3, 0);
-                if (ImGuiUtil.DrawDisabledButton("Convert to BC7", buttonSize,
-                        "This converts the texture to BC7 format in place. This is not revertible.",
-                        _left.Format is DXGIFormat.BC7Typeless or DXGIFormat.BC7UNorm or DXGIFormat.BC7UNormSRGB))
-                {
-                    _center.SaveAsTex(_textures, _left.Path, CombinedTexture.TextureSaveType.BC7, _left.MipMaps > 1);
-                    AddReloadTask(_left.Path);
-                }
-
-                ImGui.SameLine();
-                if (ImGuiUtil.DrawDisabledButton("Convert to BC3", buttonSize,
-                        "This converts the texture to BC3 format in place. This is not revertible.",
-                        _left.Format is DXGIFormat.BC3Typeless or DXGIFormat.BC3UNorm or DXGIFormat.BC3UNormSRGB))
-                {
-                    _center.SaveAsTex(_textures, _left.Path, CombinedTexture.TextureSaveType.BC3, _left.MipMaps > 1);
-                    AddReloadTask(_left.Path);
-                }
-
-                ImGui.SameLine();
-                if (ImGuiUtil.DrawDisabledButton("Convert to RGBA", buttonSize,
-                        "This converts the texture to RGBA format in place. This is not revertible.",
-                        _left.Format is DXGIFormat.B8G8R8A8UNorm or DXGIFormat.B8G8R8A8Typeless or DXGIFormat.B8G8R8A8UNormSRGB))
-                {
-                    _center.SaveAsTex(_textures, _left.Path, CombinedTexture.TextureSaveType.Bitmap, _left.MipMaps > 1);
-                    AddReloadTask(_left.Path);
-                }
+                _center.SaveAsTex(_textures, _left.Path, CombinedTexture.TextureSaveType.BC3, _left.MipMaps > 1);
+                AddReloadTask(_left.Path, false);
             }
-            else
+
+            ImGui.SameLine();
+            if (ImGuiUtil.DrawDisabledButton("Convert to RGBA", buttonSize3,
+                    "This converts the texture to RGBA format in place. This is not revertible.",
+                    !canConvertInPlace || _left.Format is DXGIFormat.B8G8R8A8UNorm or DXGIFormat.B8G8R8A8Typeless or DXGIFormat.B8G8R8A8UNormSRGB))
             {
-                ImGui.NewLine();
+                _center.SaveAsTex(_textures, _left.Path, CombinedTexture.TextureSaveType.Bitmap, _left.MipMaps > 1);
+                AddReloadTask(_left.Path, false);
             }
         }
 
@@ -212,17 +204,19 @@ public partial class ModEditWindow
             _center.Draw(_textures, imageSize);
     }
 
-    private void AddReloadTask(string path)
+    private void AddReloadTask(string path, bool right)
     {
         _center.SaveTask.ContinueWith(t =>
         {
             if (!t.IsCompletedSuccessfully)
                 return;
 
-            if (_left.Path != path)
+            var tex = right ? _right : _left;
+
+            if (tex.Path != path)
                 return;
 
-            _dalamud.Framework.RunOnFrameworkThread(() => _left.Reload(_textures));
+            _dalamud.Framework.RunOnFrameworkThread(() => tex.Reload(_textures));
         });
     }
 


### PR DESCRIPTION
- Add a constant row to the color transformation matrix, allowing for example to express per-channel inversions ;
- Add a few matrix presets (identity, grayscale, extract channel) ;
- Replace the "Invert Colors" checkbox by a button that does the same thing at the matrix level ;
- Add "Invert Red", "Invert Green", "Invert Blue", "Invert Alpha" buttons ;
- Add a "Save in place" button, that replaces the input (left) texture by the combined texture (this button is grayed out if the combined texture is an unchanged copy of the input, or if the input is a game path) ;
- Merge the "Save as TEX", "Save as DDS" and "Save as PNG" buttons into a single one that picks the format according to the extension of the destination file ;
- Let the in-place conversion buttons stay visible if they don't apply, graying them out instead, for layout consistency ;
- Also gray them out if the input is a game path ;
- Add several choices of combine operations to the overlay texture:
  - Over (standard composition, as already existed) ;
  - Under (standard composition, but in reverse) ;
  - Ignore (don't take the overlay into account) ;
  - Replace (only take the overlay into account, enabling import flows where the destination texture is selected on the left, the source is selected on the right, and "Save in place" does the job) ;
  - Copy channels (useful for importing into Multi maps, in conjunction with the extract matrix presets for exporting), with options for the channels that are to be taken from the left or from the right.