### PR TITLE
Material editor adjustments

### DIFF
--- a/Penumbra/Interop/SafeHandles/SafeTextureHandle.cs
+++ b/Penumbra/Interop/SafeHandles/SafeTextureHandle.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Render;
+using Penumbra.Interop.Structs;
+
+namespace Penumbra.Interop.SafeHandles;
+
+public unsafe class SafeTextureHandle : SafeHandle
+{
+    public Texture* Texture => (Texture*)handle;
+
+    public override bool IsInvalid => handle == 0;
+
+    public SafeTextureHandle(Texture* handle, bool incRef, bool ownsHandle = true) : base(0, ownsHandle)
+    {
+        if (incRef && !ownsHandle)
+            throw new ArgumentException("Non-owning SafeTextureHandle with IncRef is unsupported");
+        if (incRef && handle != null)
+            TextureUtility.IncRef(handle);
+        SetHandle((nint)handle);
+    }
+
+    public void Exchange(ref nint ppTexture)
+    {
+        lock (this)
+        {
+            handle = Interlocked.Exchange(ref ppTexture, handle);
+        }
+    }
+
+    public static SafeTextureHandle CreateInvalid()
+        => new(null, incRef: false);
+
+    protected override bool ReleaseHandle()
+    {
+        nint handle;
+        lock (this)
+        {
+            handle = this.handle;
+            this.handle = 0;
+        }
+        if (handle != 0)
+            TextureUtility.DecRef((Texture*)handle);
+
+        return true;
+    }
+}

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.ConstantEditor.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.ConstantEditor.cs
@@ -13,7 +13,7 @@ public partial class ModEditWindow
 {
     private interface IConstantEditor
     {
-        bool Draw(Span<float> values, bool disabled, float editorWidth);
+        bool Draw(Span<float> values, bool disabled);
     }
 
     private sealed class FloatConstantEditor : IConstantEditor
@@ -42,16 +42,18 @@ public partial class ModEditWindow
                 _format = $"{_format} {unit.Replace("%", "%%")}";
         }
 
-        public bool Draw(Span<float> values, bool disabled, float editorWidth)
+        public bool Draw(Span<float> values, bool disabled)
         {
-            var fieldWidth = (editorWidth - (values.Length - 1) * ImGui.GetStyle().ItemSpacing.X) / values.Length;
+            var spacing    = ImGui.GetStyle().ItemInnerSpacing.X;
+            var fieldWidth = (ImGui.CalcItemWidth() - (values.Length - 1) * spacing) / values.Length;
 
             var ret = false;
 
+            // Not using DragScalarN because of _relativeSpeed and other points of lost flexibility.
             for (var valueIdx = 0; valueIdx < values.Length; ++valueIdx)
             {
                 if (valueIdx > 0)
-                    ImGui.SameLine();
+                    ImGui.SameLine(0.0f, spacing);
 
                 ImGui.SetNextItemWidth(MathF.Round(fieldWidth * (valueIdx + 1)) - MathF.Round(fieldWidth * valueIdx));
 
@@ -101,16 +103,18 @@ public partial class ModEditWindow
                 _format = $"{_format} {unit.Replace("%", "%%")}";
         }
 
-        public bool Draw(Span<float> values, bool disabled, float editorWidth)
+        public bool Draw(Span<float> values, bool disabled)
         {
-            var fieldWidth = (editorWidth - (values.Length - 1) * ImGui.GetStyle().ItemSpacing.X) / values.Length;
+            var spacing    = ImGui.GetStyle().ItemInnerSpacing.X;
+            var fieldWidth = (ImGui.CalcItemWidth() - (values.Length - 1) * spacing) / values.Length;
 
             var ret = false;
 
+            // Not using DragScalarN because of _relativeSpeed and other points of lost flexibility.
             for (var valueIdx = 0; valueIdx < values.Length; ++valueIdx)
             {
                 if (valueIdx > 0)
-                    ImGui.SameLine();
+                    ImGui.SameLine(0.0f, spacing);
 
                 ImGui.SetNextItemWidth(MathF.Round(fieldWidth * (valueIdx + 1)) - MathF.Round(fieldWidth * valueIdx));
 
@@ -148,13 +152,12 @@ public partial class ModEditWindow
             _clamped    = clamped;
         }
 
-        public bool Draw(Span<float> values, bool disabled, float editorWidth)
+        public bool Draw(Span<float> values, bool disabled)
         {
             switch (values.Length)
             {
                 case 3:
                 {
-                    ImGui.SetNextItemWidth(editorWidth);
                     var value = new Vector3(values);
                     if (_squaredRgb)
                         value = PseudoSqrtRgb(value);
@@ -170,7 +173,6 @@ public partial class ModEditWindow
                 }
                 case 4:
                 {
-                    ImGui.SetNextItemWidth(editorWidth);
                     var value = new Vector4(values);
                     if (_squaredRgb)
                         value = PseudoSqrtRgb(value);
@@ -186,7 +188,7 @@ public partial class ModEditWindow
                     value.CopyTo(values);
                     return true;
                 }
-                default: return FloatConstantEditor.Default.Draw(values, disabled, editorWidth);
+                default: return FloatConstantEditor.Default.Draw(values, disabled);
             }
         }
     }
@@ -198,9 +200,10 @@ public partial class ModEditWindow
         public EnumConstantEditor(IReadOnlyList<(string Label, float Value, string Description)> values)
             => _values = values;
 
-        public bool Draw(Span<float> values, bool disabled, float editorWidth)
+        public bool Draw(Span<float> values, bool disabled)
         {
-            var fieldWidth = (editorWidth - (values.Length - 1) * ImGui.GetStyle().ItemSpacing.X) / values.Length;
+            var spacing    = ImGui.GetStyle().ItemInnerSpacing.X;
+            var fieldWidth = (ImGui.CalcItemWidth() - (values.Length - 1) * spacing) / values.Length;
 
             var ret = false;
 
@@ -208,7 +211,7 @@ public partial class ModEditWindow
             {
                 using var id = ImRaii.PushId(valueIdx);
                 if (valueIdx > 0)
-                    ImGui.SameLine();
+                    ImGui.SameLine(0.0f, spacing);
 
                 ImGui.SetNextItemWidth(MathF.Round(fieldWidth * (valueIdx + 1)) - MathF.Round(fieldWidth * valueIdx));
 

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.MtrlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.MtrlTab.cs
@@ -19,6 +19,7 @@ using Penumbra.GameData.Structs;
 using Penumbra.Interop.MaterialPreview;
 using Penumbra.String;
 using Penumbra.String.Classes;
+using Penumbra.UI.Classes;
 using static Penumbra.GameData.Files.ShpkFile;
 
 namespace Penumbra.UI.AdvancedWindow;
@@ -668,12 +669,13 @@ public partial class ModEditWindow
 
         private static void ApplyHighlight(ref MtrlFile.ColorSet.Row row, float time)
         {
-            var level   = Math.Sin(time * 2.0 * Math.PI) * 0.25 + 0.5;
-            var levelSq = (float)(level * level);
+            var level     = (MathF.Sin(time * 2.0f * MathF.PI) + 2.0f) / 3.0f / 255.0f;
+            var baseColor = ColorId.InGameHighlight.Value();
+            var color     = level * new Vector3(baseColor & 0xFF, (baseColor >> 8) & 0xFF, (baseColor >> 16) & 0xFF);
 
             row.Diffuse  = Vector3.Zero;
             row.Specular = Vector3.Zero;
-            row.Emissive = new Vector3(levelSq);
+            row.Emissive = color * color;
         }
 
         public void Update()

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.MtrlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.MtrlTab.cs
@@ -178,7 +178,7 @@ public partial class ModEditWindow
 
                 if (mayVary && (data as JObject)?["Vary"] != null)
                 {
-                    var selector = BuildSelector(data["Vary"]!
+                    var selector = BuildSelector(data!["Vary"]!
                         .Select(key => (uint)key)
                         .Select(key => Mtrl.GetShaderKey(key)?.Value ?? AssociatedShpk!.GetMaterialKeyById(key)!.Value.DefaultValue));
                     var index = (int)data["Selectors"]![selector.ToString()]!;

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.Shpk.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Materials.Shpk.cs
@@ -259,7 +259,8 @@ public partial class ModEditWindow
                 if (buffer.Length > 0)
                 {
                     using var id = ImRaii.PushId($"##{constant.Id:X8}:{slice.Start}");
-                    if (editor.Draw(buffer[slice], disabled, 250.0f))
+                    ImGui.SetNextItemWidth(250.0f);
+                    if (editor.Draw(buffer[slice], disabled))
                     {
                         ret = true;
                         tab.SetMaterialParameter(constant.Id, slice.Start, buffer[slice]);

--- a/Penumbra/UI/Classes/Colors.cs
+++ b/Penumbra/UI/Classes/Colors.cs
@@ -25,6 +25,7 @@ public enum ColorId
     NoModsAssignment,
     NoAssignment,
     SelectorPriority,
+    InGameHighlight,
 }
 
 public static class Colors
@@ -64,6 +65,7 @@ public static class Colors
             ColorId.NoModsAssignment     => ( 0x50000080, "'Use No Mods' Collection Assignment", "A collection assignment set to not use any mods at all."),
             ColorId.NoAssignment         => ( 0x00000000, "Unassigned Collection Assignment",    "A collection assignment that is not configured to any collection and thus just has no specific treatment."),
             ColorId.SelectorPriority     => ( 0xFF808080, "Mod Selector Priority",               "The priority displayed for non-zero priority mods in the mod selector."),
+            ColorId.InGameHighlight      => ( 0xFFEBCF89, "In-Game Highlight",                   "An in-game element that has been highlighted for ease of editing."),
             _                            => throw new ArgumentOutOfRangeException( nameof( color ), color, null ),
             // @formatter:on
         };


### PR DESCRIPTION
- Wrap owned `Texture*`s into a `SafeHandle`, in the spirit of owned `ResourceHandle*`s ;
- Make the highlight color customizable (the default one I'm proposing is a shade of blue web developers might have already seen a few times) ;
- Adjust vector field (for material constants) editors, and some minute ImGui things.