### PR TITLE
Check for null in SkinFixer

### DIFF
--- a/Penumbra/Interop/Services/SkinFixer.cs
+++ b/Penumbra/Interop/Services/SkinFixer.cs
@@ -90,7 +90,7 @@ public sealed unsafe class SkinFixer : IDisposable
 
     private void OnCharacterBaseCreated(nint gameObject, ModCollection collection, nint drawObject)
     {
-        if (((CharacterBase*)drawObject)->GetModelType() != CharacterBase.ModelType.Human)
+        if (drawObject == 0 || ((CharacterBase*)drawObject)->GetModelType() != CharacterBase.ModelType.Human)
             return;
 
         Task.Run(() =>


### PR DESCRIPTION
Naive fix for that reported NRE.

Should the `CharacterBaseCreated` event still be triggered when the original function returns a null pointer?