### PR TITLE
Resource Tree improvements

### DIFF
--- a/Penumbra/Interop/ResourceTree/ResolveContext.cs
+++ b/Penumbra/Interop/ResourceTree/ResolveContext.cs
@@ -283,12 +283,17 @@ internal record class ResolveContext(Configuration Config, IObjectIdentifier Ide
 
         var node = CreateNodeFromResourceHandle(ResourceType.Sklb, (nint)sklb, (ResourceHandle*)sklb->SkeletonResourceHandle, false, WithUIData);
         if (node != null)
+        {
+            var skpNode = CreateParameterNodeFromPartialSkeleton(sklb);
+            if (skpNode != null)
+                node.Children.Add(skpNode);
             Nodes.Add((nint)sklb->SkeletonResourceHandle, node);
+        }
 
         return node;
     }
 
-    public unsafe ResourceNode? CreateParameterNodeFromPartialSkeleton(FFXIVClientStructs.FFXIV.Client.Graphics.Render.PartialSkeleton* sklb)
+    private unsafe ResourceNode? CreateParameterNodeFromPartialSkeleton(FFXIVClientStructs.FFXIV.Client.Graphics.Render.PartialSkeleton* sklb)
     {
         if (sklb->SkeletonParameterResourceHandle == null)
             return null;
@@ -298,7 +303,11 @@ internal record class ResolveContext(Configuration Config, IObjectIdentifier Ide
 
         var node = CreateNodeFromResourceHandle(ResourceType.Skp, (nint)sklb, (ResourceHandle*)sklb->SkeletonParameterResourceHandle, true, WithUIData);
         if (node != null)
+        {
+            if (WithUIData)
+                node = node.WithUIData("Skeleton Parameters", node.Icon);
             Nodes.Add((nint)sklb->SkeletonParameterResourceHandle, node);
+        }
 
         return node;
     }

--- a/Penumbra/Interop/ResourceTree/ResourceNode.cs
+++ b/Penumbra/Interop/ResourceTree/ResourceNode.cs
@@ -9,37 +9,43 @@ public class ResourceNode
 {
     public readonly string?            Name;
     public readonly ResourceType       Type;
-    public readonly nint               SourceAddress;
+    public readonly nint               ObjectAddress;
+    public readonly nint               ResourceHandle;
     public readonly Utf8GamePath       GamePath;
     public readonly Utf8GamePath[]     PossibleGamePaths;
     public readonly FullPath           FullPath;
+    public readonly ulong              Length;
     public readonly bool               Internal;
     public readonly List<ResourceNode> Children;
 
-    public ResourceNode(string? name, ResourceType type, nint sourceAddress, Utf8GamePath gamePath, FullPath fullPath, bool @internal)
+    public ResourceNode(string? name, ResourceType type, nint objectAddress, nint resourceHandle, Utf8GamePath gamePath, FullPath fullPath, ulong length, bool @internal)
     {
-        Name          = name;
-        Type          = type;
-        SourceAddress = sourceAddress;
-        GamePath      = gamePath;
+        Name           = name;
+        Type           = type;
+        ObjectAddress  = objectAddress;
+        ResourceHandle = resourceHandle;
+        GamePath       = gamePath;
         PossibleGamePaths = new[]
         {
             gamePath,
         };
         FullPath = fullPath;
+        Length   = length;
         Internal = @internal;
         Children = new List<ResourceNode>();
     }
 
-    public ResourceNode(string? name, ResourceType type, nint sourceAddress, Utf8GamePath[] possibleGamePaths, FullPath fullPath,
-        bool @internal)
+    public ResourceNode(string? name, ResourceType type, nint objectAddress, nint resourceHandle, Utf8GamePath[] possibleGamePaths, FullPath fullPath,
+        ulong length, bool @internal)
     {
         Name              = name;
         Type              = type;
-        SourceAddress     = sourceAddress;
+        ObjectAddress     = objectAddress;
+        ResourceHandle    = resourceHandle;
         GamePath          = possibleGamePaths.Length == 1 ? possibleGamePaths[0] : Utf8GamePath.Empty;
         PossibleGamePaths = possibleGamePaths;
         FullPath          = fullPath;
+        Length            = length;
         Internal          = @internal;
         Children          = new List<ResourceNode>();
     }
@@ -48,10 +54,12 @@ public class ResourceNode
     {
         Name              = name;
         Type              = originalResourceNode.Type;
-        SourceAddress     = originalResourceNode.SourceAddress;
+        ObjectAddress     = originalResourceNode.ObjectAddress;
+        ResourceHandle    = originalResourceNode.ResourceHandle;
         GamePath          = originalResourceNode.GamePath;
         PossibleGamePaths = originalResourceNode.PossibleGamePaths;
         FullPath          = originalResourceNode.FullPath;
+        Length            = originalResourceNode.Length;
         Internal          = originalResourceNode.Internal;
         Children          = originalResourceNode.Children;
     }

--- a/Penumbra/Interop/ResourceTree/ResourceNode.cs
+++ b/Penumbra/Interop/ResourceTree/ResourceNode.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using Penumbra.GameData.Enums;
 using Penumbra.String.Classes;
+using ChangedItemIcon = Penumbra.UI.ChangedItemDrawer.ChangedItemIcon;
 
 namespace Penumbra.Interop.ResourceTree;
 
 public class ResourceNode
 {
     public readonly string?            Name;
+    public readonly ChangedItemIcon    Icon;
     public readonly ResourceType       Type;
     public readonly nint               ObjectAddress;
     public readonly nint               ResourceHandle;
@@ -18,9 +20,11 @@ public class ResourceNode
     public readonly bool               Internal;
     public readonly List<ResourceNode> Children;
 
-    public ResourceNode(string? name, ResourceType type, nint objectAddress, nint resourceHandle, Utf8GamePath gamePath, FullPath fullPath, ulong length, bool @internal)
+    public ResourceNode(UIData uiData, ResourceType type, nint objectAddress, nint resourceHandle, Utf8GamePath gamePath, FullPath fullPath,
+        ulong length, bool @internal)
     {
-        Name           = name;
+        Name           = uiData.Name;
+        Icon           = uiData.Icon;
         Type           = type;
         ObjectAddress  = objectAddress;
         ResourceHandle = resourceHandle;
@@ -35,10 +39,11 @@ public class ResourceNode
         Children = new List<ResourceNode>();
     }
 
-    public ResourceNode(string? name, ResourceType type, nint objectAddress, nint resourceHandle, Utf8GamePath[] possibleGamePaths, FullPath fullPath,
+    public ResourceNode(UIData uiData, ResourceType type, nint objectAddress, nint resourceHandle, Utf8GamePath[] possibleGamePaths, FullPath fullPath,
         ulong length, bool @internal)
     {
-        Name              = name;
+        Name              = uiData.Name;
+        Icon              = uiData.Icon;
         Type              = type;
         ObjectAddress     = objectAddress;
         ResourceHandle    = resourceHandle;
@@ -50,9 +55,10 @@ public class ResourceNode
         Children          = new List<ResourceNode>();
     }
 
-    private ResourceNode(string? name, ResourceNode originalResourceNode)
+    private ResourceNode(UIData uiData, ResourceNode originalResourceNode)
     {
-        Name              = name;
+        Name              = uiData.Name;
+        Icon              = uiData.Icon;
         Type              = originalResourceNode.Type;
         ObjectAddress     = originalResourceNode.ObjectAddress;
         ResourceHandle    = originalResourceNode.ResourceHandle;
@@ -64,6 +70,15 @@ public class ResourceNode
         Children          = originalResourceNode.Children;
     }
 
-    public ResourceNode WithName(string? name)
-        => string.Equals(Name, name, StringComparison.Ordinal) ? this : new ResourceNode(name, this);
+    public ResourceNode WithUIData(string? name, ChangedItemIcon icon)
+        => string.Equals(Name, name, StringComparison.Ordinal) && Icon == icon ? this : new ResourceNode(new(name, icon), this);
+
+    public ResourceNode WithUIData(UIData uiData)
+        => string.Equals(Name, uiData.Name, StringComparison.Ordinal) && Icon == uiData.Icon ? this : new ResourceNode(uiData, this);
+
+    public readonly record struct UIData(string? Name, ChangedItemIcon Icon)
+    {
+        public readonly UIData PrependName(string prefix)
+            => Name == null ? this : new(prefix + Name, Icon);
+    }
 }

--- a/Penumbra/Interop/ResourceTree/ResourceTree.cs
+++ b/Penumbra/Interop/ResourceTree/ResourceTree.cs
@@ -134,10 +134,6 @@ public class ResourceTree
             var sklbNode = context.CreateNodeFromPartialSkeleton(&skeleton->PartialSkeletons[i]);
             if (sklbNode != null)
                 nodes.Add(context.WithUIData ? sklbNode.WithUIData($"{prefix}Skeleton #{i}", sklbNode.Icon) : sklbNode);
-
-            var skpNode = context.CreateParameterNodeFromPartialSkeleton(&skeleton->PartialSkeletons[i]);
-            if (skpNode != null)
-                nodes.Add(context.WithUIData ? skpNode.WithUIData($"{prefix}Skeleton #{i} Parameters", skpNode.Icon) : skpNode);
         }
     }
 }

--- a/Penumbra/Interop/ResourceTree/ResourceTree.cs
+++ b/Penumbra/Interop/ResourceTree/ResourceTree.cs
@@ -13,29 +13,33 @@ namespace Penumbra.Interop.ResourceTree;
 
 public class ResourceTree
 {
-    public readonly string             Name;
-    public readonly nint               SourceAddress;
-    public readonly bool               PlayerRelated;
-    public readonly string             CollectionName;
-    public readonly List<ResourceNode> Nodes;
+    public readonly string                Name;
+    public readonly nint                  GameObjectAddress;
+    public readonly nint                  DrawObjectAddress;
+    public readonly bool                  PlayerRelated;
+    public readonly string                CollectionName;
+    public readonly List<ResourceNode>    Nodes;
+    public readonly HashSet<ResourceNode> FlatNodes;
 
     public int           ModelId;
     public CustomizeData CustomizeData;
     public GenderRace    RaceCode;
 
-    public ResourceTree(string name, nint sourceAddress, bool playerRelated, string collectionName)
+    public ResourceTree(string name, nint gameObjectAddress, nint drawObjectAddress, bool playerRelated, string collectionName)
     {
-        Name           = name;
-        SourceAddress  = sourceAddress;
-        PlayerRelated  = playerRelated;
-        CollectionName = collectionName;
-        Nodes          = new List<ResourceNode>();
+        Name              = name;
+        GameObjectAddress = gameObjectAddress;
+        DrawObjectAddress = drawObjectAddress;
+        PlayerRelated     = playerRelated;
+        CollectionName    = collectionName;
+        Nodes             = new List<ResourceNode>();
+        FlatNodes         = new HashSet<ResourceNode>();
     }
 
     internal unsafe void LoadResources(GlobalResolveContext globalContext)
     {
-        var character = (Character*)SourceAddress;
-        var model     = (CharacterBase*)character->GameObject.GetDrawObject();
+        var character = (Character*)GameObjectAddress;
+        var model     = (CharacterBase*)DrawObjectAddress;
         var equipment = new ReadOnlySpan<CharacterArmor>(&character->DrawData.Head, 10);
         // var customize = new ReadOnlySpan<byte>( character->CustomizeData, 26 );
         ModelId       = character->CharacterData.ModelCharaId;
@@ -130,6 +134,10 @@ public class ResourceTree
             var sklbNode = context.CreateNodeFromPartialSkeleton(&skeleton->PartialSkeletons[i]);
             if (sklbNode != null)
                 nodes.Add(context.WithNames ? sklbNode.WithName($"{prefix}Skeleton #{i}") : sklbNode);
+
+            var skpNode = context.CreateParameterNodeFromPartialSkeleton(&skeleton->PartialSkeletons[i]);
+            if (skpNode != null)
+                nodes.Add(context.WithNames ? skpNode.WithName($"{prefix}Skeleton #{i} Parameters") : skpNode);
         }
     }
 }

--- a/Penumbra/Interop/ResourceTree/ResourceTree.cs
+++ b/Penumbra/Interop/ResourceTree/ResourceTree.cs
@@ -56,12 +56,12 @@ public class ResourceTree
             var imc     = (ResourceHandle*)model->IMCArray[i];
             var imcNode = context.CreateNodeFromImc(imc);
             if (imcNode != null)
-                Nodes.Add(globalContext.WithNames ? imcNode.WithName(imcNode.Name ?? $"IMC #{i}") : imcNode);
+                Nodes.Add(globalContext.WithUIData ? imcNode.WithUIData(imcNode.Name ?? $"IMC #{i}", imcNode.Icon) : imcNode);
 
             var mdl     = (RenderModel*)model->Models[i];
             var mdlNode = context.CreateNodeFromRenderModel(mdl);
             if (mdlNode != null)
-                Nodes.Add(globalContext.WithNames ? mdlNode.WithName(mdlNode.Name ?? $"Model #{i}") : mdlNode);
+                Nodes.Add(globalContext.WithUIData ? mdlNode.WithUIData(mdlNode.Name ?? $"Model #{i}", mdlNode.Icon) : mdlNode);
         }
 
         AddSkeleton(Nodes, globalContext.CreateContext(EquipSlot.Unknown, default), model->Skeleton);
@@ -92,15 +92,15 @@ public class ResourceTree
                     var imc     = (ResourceHandle*)subObject->IMCArray[i];
                     var imcNode = subObjectContext.CreateNodeFromImc(imc);
                     if (imcNode != null)
-                        subObjectNodes.Add(globalContext.WithNames
-                            ? imcNode.WithName(imcNode.Name ?? $"{subObjectNamePrefix} #{subObjectIndex}, IMC #{i}")
+                        subObjectNodes.Add(globalContext.WithUIData
+                            ? imcNode.WithUIData(imcNode.Name ?? $"{subObjectNamePrefix} #{subObjectIndex}, IMC #{i}", imcNode.Icon)
                             : imcNode);
 
                     var mdl     = (RenderModel*)subObject->Models[i];
                     var mdlNode = subObjectContext.CreateNodeFromRenderModel(mdl);
                     if (mdlNode != null)
-                        subObjectNodes.Add(globalContext.WithNames
-                            ? mdlNode.WithName(mdlNode.Name ?? $"{subObjectNamePrefix} #{subObjectIndex}, Model #{i}")
+                        subObjectNodes.Add(globalContext.WithUIData
+                            ? mdlNode.WithUIData(mdlNode.Name ?? $"{subObjectNamePrefix} #{subObjectIndex}, Model #{i}", mdlNode.Icon)
                             : mdlNode);
                 }
 
@@ -117,11 +117,11 @@ public class ResourceTree
 
         var decalNode = context.CreateNodeFromTex((TextureResourceHandle*)human->Decal);
         if (decalNode != null)
-            Nodes.Add(globalContext.WithNames ? decalNode.WithName(decalNode.Name ?? "Face Decal") : decalNode);
+            Nodes.Add(globalContext.WithUIData ? decalNode.WithUIData(decalNode.Name ?? "Face Decal", decalNode.Icon) : decalNode);
 
         var legacyDecalNode = context.CreateNodeFromTex((TextureResourceHandle*)human->LegacyBodyDecal);
         if (legacyDecalNode != null)
-            Nodes.Add(globalContext.WithNames ? legacyDecalNode.WithName(legacyDecalNode.Name ?? "Legacy Body Decal") : legacyDecalNode);
+            Nodes.Add(globalContext.WithUIData ? legacyDecalNode.WithUIData(legacyDecalNode.Name ?? "Legacy Body Decal", legacyDecalNode.Icon) : legacyDecalNode);
     }
 
     private unsafe void AddSkeleton(List<ResourceNode> nodes, ResolveContext context, Skeleton* skeleton, string prefix = "")
@@ -133,11 +133,11 @@ public class ResourceTree
         {
             var sklbNode = context.CreateNodeFromPartialSkeleton(&skeleton->PartialSkeletons[i]);
             if (sklbNode != null)
-                nodes.Add(context.WithNames ? sklbNode.WithName($"{prefix}Skeleton #{i}") : sklbNode);
+                nodes.Add(context.WithUIData ? sklbNode.WithUIData($"{prefix}Skeleton #{i}", sklbNode.Icon) : sklbNode);
 
             var skpNode = context.CreateParameterNodeFromPartialSkeleton(&skeleton->PartialSkeletons[i]);
             if (skpNode != null)
-                nodes.Add(context.WithNames ? skpNode.WithName($"{prefix}Skeleton #{i} Parameters") : skpNode);
+                nodes.Add(context.WithUIData ? skpNode.WithUIData($"{prefix}Skeleton #{i} Parameters", skpNode.Icon) : skpNode);
         }
     }
 }

--- a/Penumbra/Interop/ResourceTree/ResourceTreeFactory.cs
+++ b/Penumbra/Interop/ResourceTree/ResourceTreeFactory.cs
@@ -62,7 +62,8 @@ public class ResourceTreeFactory
             return null;
 
         var gameObjStruct = (GameObject*)character.Address;
-        if (gameObjStruct->GetDrawObject() == null)
+        var drawObjStruct = gameObjStruct->GetDrawObject();
+        if (drawObjStruct == null)
             return null;
 
         var collectionResolveData = _collectionResolver.IdentifyCollection(gameObjStruct, true);
@@ -70,10 +71,11 @@ public class ResourceTreeFactory
             return null;
 
         var (name, related) = GetCharacterName(character, cache);
-        var tree = new ResourceTree(name, (nint)gameObjStruct, related, collectionResolveData.ModCollection.Name);
+        var tree = new ResourceTree(name, (nint)gameObjStruct, (nint)drawObjStruct, related, collectionResolveData.ModCollection.Name);
         var globalContext = new GlobalResolveContext(_config, _identifier.AwaitedService, cache, collectionResolveData.ModCollection,
             ((Character*)gameObjStruct)->CharacterData.ModelCharaId, withNames);
         tree.LoadResources(globalContext);
+        tree.FlatNodes.UnionWith(globalContext.Nodes.Values);
         return tree;
     }
 

--- a/Penumbra/Interop/ResourceTree/TreeBuildCache.cs
+++ b/Penumbra/Interop/ResourceTree/TreeBuildCache.cs
@@ -12,7 +12,6 @@ namespace Penumbra.Interop.ResourceTree;
 internal class TreeBuildCache
 {
     private readonly IDataManager                    _dataManager;
-    private readonly Dictionary<FullPath, MtrlFile?> _materials      = new();
     private readonly Dictionary<FullPath, ShpkFile?> _shaderPackages = new();
     public readonly  List<Character>                 Characters;
     public readonly  Dictionary<uint, Character>     CharactersById;
@@ -26,10 +25,6 @@ internal class TreeBuildCache
             .GroupBy(c => c.ObjectId)
             .ToDictionary(c => c.Key, c => c.First());
     }
-
-    /// <summary> Try to read a material file from the given path and cache it on success. </summary>
-    public MtrlFile? ReadMaterial(FullPath path)
-        => ReadFile(_dataManager, path, _materials, bytes => new MtrlFile(bytes));
 
     /// <summary> Try to read a shpk file from the given path and cache it on success. </summary>
     public ShpkFile? ReadShaderPackage(FullPath path)

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.cs
@@ -554,7 +554,8 @@ public partial class ModEditWindow : Window, IDisposable
     public ModEditWindow(PerformanceTracker performance, FileDialogService fileDialog, ItemSwapTab itemSwapTab, IDataManager gameData,
         Configuration config, ModEditor editor, ResourceTreeFactory resourceTreeFactory, MetaFileManager metaFileManager,
         StainService stainService, ActiveCollections activeCollections, DalamudServices dalamud, ModMergeTab modMergeTab,
-        CommunicatorService communicator, TextureManager textures, IDragDropManager dragDropManager, GameEventManager gameEvents)
+        CommunicatorService communicator, TextureManager textures, IDragDropManager dragDropManager, GameEventManager gameEvents,
+        ChangedItemDrawer changedItemDrawer)
         : base(WindowBaseLabel)
     {
         _performance       = performance;
@@ -581,7 +582,7 @@ public partial class ModEditWindow : Window, IDisposable
             (bytes, _, _) => new ShpkTab(_fileDialog, bytes));
         _center             = new CombinedTexture(_left, _right);
         _textureSelectCombo = new TextureDrawer.PathSelectCombo(textures, editor);
-        _quickImportViewer  = new ResourceTreeViewer(_config, resourceTreeFactory, 2, OnQuickImportRefresh, DrawQuickImportActions);
+        _quickImportViewer  = new ResourceTreeViewer(_config, resourceTreeFactory, changedItemDrawer, 2, OnQuickImportRefresh, DrawQuickImportActions);
         _communicator.ModPathChanged.Subscribe(OnModPathChanged, ModPathChanged.Priority.ModEditWindow);
     }
 

--- a/Penumbra/UI/AdvancedWindow/ResourceTreeViewer.cs
+++ b/Penumbra/UI/AdvancedWindow/ResourceTreeViewer.cs
@@ -128,7 +128,7 @@ public class ResourceTreeViewer
 
                 if (debugMode)
                     ImGuiUtil.HoverTooltip(
-                        $"Resource Type: {resourceNode.Type}\nSource Address: 0x{resourceNode.SourceAddress:X16}");
+                        $"Resource Type: {resourceNode.Type}\nObject Address: 0x{resourceNode.ObjectAddress:X16}\nResource Handle: 0x{resourceNode.ResourceHandle:X16}\nLength: 0x{resourceNode.Length:X}");
             }
 
             ImGui.TableNextColumn();

--- a/Penumbra/UI/AdvancedWindow/ResourceTreeViewer.cs
+++ b/Penumbra/UI/AdvancedWindow/ResourceTreeViewer.cs
@@ -18,7 +18,7 @@ public class ResourceTreeViewer
     private readonly int                           _actionCapacity;
     private readonly Action                        _onRefresh;
     private readonly Action<ResourceNode, Vector2> _drawActions;
-    private readonly HashSet<ResourceNode>         _unfolded;
+    private readonly HashSet<nint>                 _unfolded;
 
     private Task<ResourceTree[]>?      _task;
 
@@ -30,7 +30,7 @@ public class ResourceTreeViewer
         _actionCapacity = actionCapacity;
         _onRefresh      = onRefresh;
         _drawActions    = drawActions;
-        _unfolded       = new HashSet<ResourceNode>();
+        _unfolded       = new HashSet<nint>();
     }
 
     public void Draw()
@@ -82,7 +82,7 @@ public class ResourceTreeViewer
                         (_actionCapacity - 1) * 3 * ImGuiHelpers.GlobalScale + _actionCapacity * ImGui.GetFrameHeight());
                 ImGui.TableHeadersRow();
 
-                DrawNodes(tree.Nodes, 0);
+                DrawNodes(tree.Nodes, 0, 0);
             }
         }
     }
@@ -101,7 +101,7 @@ public class ResourceTreeViewer
             }
         });
 
-    private void DrawNodes(IEnumerable<ResourceNode> resourceNodes, int level)
+    private void DrawNodes(IEnumerable<ResourceNode> resourceNodes, int level, nint pathHash)
     {
         var debugMode   = _config.DebugMode;
         var frameHeight = ImGui.GetFrameHeight();
@@ -111,24 +111,34 @@ public class ResourceTreeViewer
             if (resourceNode.Internal && !debugMode)
                 continue;
 
+            var textColor         = ImGui.GetColorU32(ImGuiCol.Text);
+            var textColorInternal = (textColor & 0x00FFFFFFu) | ((textColor & 0xFE000000u) >> 1); // Half opacity
+
+            using var mutedColor = ImRaii.PushColor(ImGuiCol.Text, textColorInternal, resourceNode.Internal);
+
+            var nodePathHash = unchecked(pathHash + resourceNode.ResourceHandle);
+
             using var id = ImRaii.PushId(index);
             ImGui.TableNextColumn();
-            var unfolded = _unfolded.Contains(resourceNode);
+            var unfolded = _unfolded.Contains(nodePathHash);
             using (var indent = ImRaii.PushIndent(level))
             {
                 ImGui.TableHeader((resourceNode.Children.Count > 0 ? unfolded ? "[-] " : "[+] " : string.Empty) + resourceNode.Name);
                 if (ImGui.IsItemClicked() && resourceNode.Children.Count > 0)
                 {
                     if (unfolded)
-                        _unfolded.Remove(resourceNode);
+                        _unfolded.Remove(nodePathHash);
                     else
-                        _unfolded.Add(resourceNode);
+                        _unfolded.Add(nodePathHash);
                     unfolded = !unfolded;
                 }
 
                 if (debugMode)
+                {
+                    using var _ = ImRaii.PushFont(UiBuilder.MonoFont);
                     ImGuiUtil.HoverTooltip(
-                        $"Resource Type: {resourceNode.Type}\nObject Address: 0x{resourceNode.ObjectAddress:X16}\nResource Handle: 0x{resourceNode.ResourceHandle:X16}\nLength: 0x{resourceNode.Length:X}");
+                        $"Resource Type:   {resourceNode.Type}\nObject Address:  0x{resourceNode.ObjectAddress:X16}\nResource Handle: 0x{resourceNode.ResourceHandle:X16}\nLength:          0x{resourceNode.Length:X16}");
+                }
             }
 
             ImGui.TableNextColumn();
@@ -171,7 +181,7 @@ public class ResourceTreeViewer
             }
 
             if (unfolded)
-                DrawNodes(resourceNode.Children, level + 1);
+                DrawNodes(resourceNode.Children, level + 1, unchecked(nodePathHash * 31));
         }
     }
 }

--- a/Penumbra/UI/AdvancedWindow/ResourceTreeViewer.cs
+++ b/Penumbra/UI/AdvancedWindow/ResourceTreeViewer.cs
@@ -8,6 +8,7 @@ using OtterGui.Raii;
 using OtterGui;
 using Penumbra.Interop.ResourceTree;
 using Penumbra.UI.Classes;
+using System.Linq;
 
 namespace Penumbra.UI.AdvancedWindow;
 
@@ -125,7 +126,10 @@ public class ResourceTreeViewer
             var unfolded = _unfolded.Contains(nodePathHash);
             using (var indent = ImRaii.PushIndent(level))
             {
-                if (resourceNode.Children.Count > 0)
+                var unfoldable = debugMode
+                    ? resourceNode.Children.Count > 0
+                    : resourceNode.Children.Any(child => !child.Internal);
+                if (unfoldable)
                 {
                     using var font = ImRaii.PushFont(UiBuilder.IconFont);
                     var icon = (unfolded ? FontAwesomeIcon.CaretDown : FontAwesomeIcon.CaretRight).ToIconString();
@@ -142,7 +146,7 @@ public class ResourceTreeViewer
                 _changedItemDrawer.DrawCategoryIcon(resourceNode.Icon);
                 ImGui.SameLine(0f, ImGui.GetStyle().ItemInnerSpacing.X);
                 ImGui.TableHeader(resourceNode.Name);
-                if (ImGui.IsItemClicked() && resourceNode.Children.Count > 0)
+                if (ImGui.IsItemClicked() && unfoldable)
                 {
                     if (unfolded)
                         _unfolded.Remove(nodePathHash);

--- a/Penumbra/UI/AdvancedWindow/ResourceTreeViewer.cs
+++ b/Penumbra/UI/AdvancedWindow/ResourceTreeViewer.cs
@@ -85,7 +85,7 @@ public class ResourceTreeViewer
                         (_actionCapacity - 1) * 3 * ImGuiHelpers.GlobalScale + _actionCapacity * ImGui.GetFrameHeight());
                 ImGui.TableHeadersRow();
 
-                DrawNodes(tree.Nodes, 0, 0);
+                DrawNodes(tree.Nodes, 0, unchecked(tree.DrawObjectAddress * 31));
             }
         }
     }

--- a/Penumbra/UI/ChangedItemDrawer.cs
+++ b/Penumbra/UI/ChangedItemDrawer.cs
@@ -76,9 +76,11 @@ public class ChangedItemDrawer : IDisposable
 
     /// <summary> Draw the icon corresponding to the category of a changed item. </summary>
     public void DrawCategoryIcon(string name, object? data)
+        => DrawCategoryIcon(GetCategoryIcon(name, data));
+
+    public void DrawCategoryIcon(ChangedItemIcon iconType)
     {
-        var height   = ImGui.GetFrameHeight();
-        var iconType = GetCategoryIcon(name, data);
+        var height = ImGui.GetFrameHeight();
         if (!_icons.TryGetValue(iconType, out var icon))
         {
             ImGui.Dummy(new Vector2(height));
@@ -216,27 +218,13 @@ public class ChangedItemDrawer : IDisposable
     }
 
     /// <summary> Obtain the icon category corresponding to a changed item. </summary>
-    private static ChangedItemIcon GetCategoryIcon(string name, object? obj)
+    internal static ChangedItemIcon GetCategoryIcon(string name, object? obj)
     {
         var iconType = ChangedItemIcon.Unknown;
         switch (obj)
         {
             case EquipItem it:
-                iconType = it.Type.ToSlot() switch
-                {
-                    EquipSlot.MainHand => ChangedItemIcon.Mainhand,
-                    EquipSlot.OffHand  => ChangedItemIcon.Offhand,
-                    EquipSlot.Head     => ChangedItemIcon.Head,
-                    EquipSlot.Body     => ChangedItemIcon.Body,
-                    EquipSlot.Hands    => ChangedItemIcon.Hands,
-                    EquipSlot.Legs     => ChangedItemIcon.Legs,
-                    EquipSlot.Feet     => ChangedItemIcon.Feet,
-                    EquipSlot.Ears     => ChangedItemIcon.Ears,
-                    EquipSlot.Neck     => ChangedItemIcon.Neck,
-                    EquipSlot.Wrists   => ChangedItemIcon.Wrists,
-                    EquipSlot.RFinger  => ChangedItemIcon.Finger,
-                    _                  => ChangedItemIcon.Unknown,
-                };
+                iconType = GetCategoryIcon(it.Type.ToSlot());
                 break;
             case ModelChara m:
                 iconType = (CharacterBase.ModelType)m.Type switch
@@ -258,6 +246,23 @@ public class ChangedItemDrawer : IDisposable
 
         return iconType;
     }
+
+    internal static ChangedItemIcon GetCategoryIcon(EquipSlot slot)
+        => slot switch
+        {
+            EquipSlot.MainHand => ChangedItemIcon.Mainhand,
+            EquipSlot.OffHand  => ChangedItemIcon.Offhand,
+            EquipSlot.Head     => ChangedItemIcon.Head,
+            EquipSlot.Body     => ChangedItemIcon.Body,
+            EquipSlot.Hands    => ChangedItemIcon.Hands,
+            EquipSlot.Legs     => ChangedItemIcon.Legs,
+            EquipSlot.Feet     => ChangedItemIcon.Feet,
+            EquipSlot.Ears     => ChangedItemIcon.Ears,
+            EquipSlot.Neck     => ChangedItemIcon.Neck,
+            EquipSlot.Wrists   => ChangedItemIcon.Wrists,
+            EquipSlot.RFinger  => ChangedItemIcon.Finger,
+            _                  => ChangedItemIcon.Unknown,
+        };
 
     /// <summary> Return more detailed object information in text, if it exists. </summary>
     private static bool GetChangedItemObject(object? obj, out string text)

--- a/Penumbra/UI/Tabs/OnScreenTab.cs
+++ b/Penumbra/UI/Tabs/OnScreenTab.cs
@@ -10,10 +10,10 @@ public class OnScreenTab : ITab
     private readonly Configuration      _config;
     private          ResourceTreeViewer _viewer;
 
-    public OnScreenTab(Configuration config, ResourceTreeFactory treeFactory)
+    public OnScreenTab(Configuration config, ResourceTreeFactory treeFactory, ChangedItemDrawer changedItemDrawer)
     {
         _config = config;
-        _viewer = new ResourceTreeViewer(_config, treeFactory, 0, delegate { }, delegate { });
+        _viewer = new ResourceTreeViewer(_config, treeFactory, changedItemDrawer, 0, delegate { }, delegate { });
     }
 
     public ReadOnlySpan<byte> Label


### PR DESCRIPTION
# Materials
- Avoid some of the I/O to determine texture/sampler names (now only the shpk files are re-read from disk, the sampler IDs are pulled from the in-memory structures already used by ME99) ;
- This should make the texture name guesser more effective, as a side-effect.

# Skeletons
- Use the in-memory skeleton structure to pull all the relevant sklb files, not just the base one (obligatory "Xande when?" :trollface:) ;
- Add skp files, as sub-nodes of associated sklb files.

# Shaders and Textures
- Pull the full paths from the resource handles instead of resolving them through the collection, for consistency with the rest of the system.

# General back-end
- Pull both instantiated object address and resource handle, where applicable, to show them in debug mode ;
- Deduplicate nodes where applicable, to avoid recalculation of the whole sub-tree of shared materials – technically, that makes the thing a Resource DAG, not a tree anymore, I didn't rename it though ;
- Make redacting of full paths that are neither vanilla paths nor within the Penumbra root directory optional, in preparation of "get local player redirections" IPC (in On-Screen / Import from Screen, they will stay redacted).

# Resource Tree Viewer
- Add ChangedItem-like icons to the rows ;
- Rework the fold/unfold glyphs (using the same as the sampler fold/unfold buttons in ME99) and alignment ;
- Make sure a row won't appear unfoldable if it has no visible child rows (i. e. not in debug mode and all child rows are internal, which can happen now with skp) ;
- Make internal nodes appear "grayed out".