### PR TITLE
Resource Tree: Use `/`s for game actual paths

### DIFF
--- a/Penumbra/UI/AdvancedWindow/ResourceTreeViewer.cs
+++ b/Penumbra/UI/AdvancedWindow/ResourceTreeViewer.cs
@@ -182,9 +182,9 @@ public class ResourceTreeViewer
             ImGui.TableNextColumn();
             if (resourceNode.FullPath.FullName.Length > 0)
             {
-                ImGui.Selectable(resourceNode.FullPath.ToString(), false, 0, new Vector2(ImGui.GetContentRegionAvail().X, cellHeight));
+                ImGui.Selectable(resourceNode.FullPath.ToPath(), false, 0, new Vector2(ImGui.GetContentRegionAvail().X, cellHeight));
                 if (ImGui.IsItemClicked())
-                    ImGui.SetClipboardText(resourceNode.FullPath.ToString());
+                    ImGui.SetClipboardText(resourceNode.FullPath.ToPath());
                 ImGuiUtil.HoverTooltip($"{resourceNode.FullPath}\n\nClick to copy to clipboard.");
             }
             else


### PR DESCRIPTION
Fixes a quirk where the path a user would copy from the RT would be unusable as-is in the other tabs (see discussion on Discord).