### PR TITLE
Add alternative link format for repository validation

### DIFF
--- a/Penumbra/Services/ValidityChecker.cs
+++ b/Penumbra/Services/ValidityChecker.cs
@@ -5,10 +5,12 @@ namespace Penumbra.Services;
 
 public class ValidityChecker
 {
-    public const string Repository      = "https://raw.githubusercontent.com/xivdev/Penumbra/master/repo.json";
-    public const string SeaOfStars      = "https://raw.githubusercontent.com/Ottermandias/SeaOfStars/main/repo.json";
-    public const string RepositoryLower = "https://raw.githubusercontent.com/xivdev/penumbra/master/repo.json";
-    public const string SeaOfStarsLower = "https://raw.githubusercontent.com/ottermandias/seaofstars/main/repo.json";
+    public const string Repository         = "https://raw.githubusercontent.com/xivdev/Penumbra/master/repo.json";
+    public const string SeaOfStars         = "https://raw.githubusercontent.com/Ottermandias/SeaOfStars/main/repo.json";
+    public const string RepositoryLower    = "https://raw.githubusercontent.com/xivdev/penumbra/master/repo.json";
+    public const string SeaOfStarsLower    = "https://raw.githubusercontent.com/ottermandias/seaofstars/main/repo.json";
+    public const string RepositoryAltLower = "https://github.com/xivdev/penumbra/raw/master/repo.json";
+    public const string SeaOfStarsAltLower = "https://github.com/ottermandias/seaofstars/raw/main/repo.json;
 
     public readonly bool DevPenumbraExists;
     public readonly bool IsNotInstalledPenumbra;
@@ -84,6 +86,8 @@ public class ValidityChecker
             null                => false,
             RepositoryLower     => true,
             SeaOfStarsLower     => true,
+            RepositoryAltLower  => true,
+            SeaOfStarsAltLower  => true,
             _                   => false,
         };
 #else

--- a/Penumbra/Services/ValidityChecker.cs
+++ b/Penumbra/Services/ValidityChecker.cs
@@ -10,7 +10,7 @@ public class ValidityChecker
     public const string RepositoryLower    = "https://raw.githubusercontent.com/xivdev/penumbra/master/repo.json";
     public const string SeaOfStarsLower    = "https://raw.githubusercontent.com/ottermandias/seaofstars/main/repo.json";
     public const string RepositoryAltLower = "https://github.com/xivdev/penumbra/raw/master/repo.json";
-    public const string SeaOfStarsAltLower = "https://github.com/ottermandias/seaofstars/raw/main/repo.json;
+    public const string SeaOfStarsAltLower = "https://github.com/ottermandias/seaofstars/raw/main/repo.json";
 
     public readonly bool DevPenumbraExists;
     public readonly bool IsNotInstalledPenumbra;


### PR DESCRIPTION
There are multiple valid URLs that can access the same raw file on Git Hub. If somebody used the URLs added in this commit they would get a validation error despite using an approved repository.

In particular, I found an issue when adding SeaOfStars repository through UnknownX7's plugin repository browser. While it's something that could be fixed on their end in the repo manifest list, I do believe that it's a validation error (False negative validation) that should be addressed here.