### PR TITLE
Disable window sounds in ImportPopup

### DIFF
--- a/Penumbra/UI/ImportPopup.cs
+++ b/Penumbra/UI/ImportPopup.cs
@@ -29,10 +29,11 @@ public sealed class ImportPopup : Window
           | ImGuiWindowFlags.NoDocking
           | ImGuiWindowFlags.NoTitleBar, true)
     {
-        _modImportManager  = modImportManager;
-        IsOpen             = true;
-        RespectCloseHotkey = false;
-        Collapsed          = false;
+        _modImportManager   = modImportManager;
+        DisableWindowSounds = true;
+        IsOpen              = true;
+        RespectCloseHotkey  = false;
+        Collapsed           = false;
         SizeConstraints = new WindowSizeConstraints
         {
             MinimumSize = Vector2.Zero,


### PR DESCRIPTION
Dalamud added open/close sound effects for plugin windows (Dalamud Settings -> Look & Feel tab) a while back.
Every time the game starts it makes the open window sound, because the `ImportPopup` window didn't disable them and is opened when plugin loads.
This PR disables the sounds in that window.