### PR TITLE
Redraw player ornament, allow redrawing by index

### DIFF
--- a/Penumbra/Interop/Services/RedrawService.cs
+++ b/Penumbra/Interop/Services/RedrawService.cs
@@ -154,11 +154,11 @@ public sealed unsafe partial class RedrawService : IDisposable
         if (gPose)
             DisableDraw(actor!);
 
-        if (actor is PlayerCharacter && _objects[tableIndex + 1] is { ObjectKind: ObjectKind.MountType } mount)
+        if (actor is PlayerCharacter && _objects[tableIndex + 1] is { ObjectKind: ObjectKind.MountType or ObjectKind.Ornament } mountOrOrnament)
         {
-            *ActorDrawState(mount) |= DrawState.Invisibility;
+            *ActorDrawState(mountOrOrnament) |= DrawState.Invisibility;
             if (gPose)
-                DisableDraw(mount);
+                DisableDraw(mountOrOrnament);
         }
     }
 
@@ -173,11 +173,11 @@ public sealed unsafe partial class RedrawService : IDisposable
         if (gPose)
             EnableDraw(actor!);
 
-        if (actor is PlayerCharacter && _objects[tableIndex + 1] is { ObjectKind: ObjectKind.MountType } mount)
+        if (actor is PlayerCharacter && _objects[tableIndex + 1] is { ObjectKind: ObjectKind.MountType or ObjectKind.Ornament } mountOrOrnament)
         {
-            *ActorDrawState(mount) &= ~DrawState.Invisibility;
+            *ActorDrawState(mountOrOrnament) &= ~DrawState.Invisibility;
             if (gPose)
-                EnableDraw(mount);
+                EnableDraw(mountOrOrnament);
         }
 
         GameObjectRedrawn?.Invoke(actor!.Address, tableIndex);
@@ -323,6 +323,12 @@ public sealed unsafe partial class RedrawService : IDisposable
             "mouseover" => (_targets.MouseOverTarget, true),
             _           => (null, false),
         };
+        if (!ret && lowerName.Length > 1 && lowerName[0] == '#' && ushort.TryParse(lowerName[1..], out var objectIndex))
+        {
+            ret   = true;
+            actor = _objects[objectIndex];
+        }
+
         return ret;
     }
 


### PR DESCRIPTION
- Redrawing a player now redraws their ornament (aka fashion accessory, umbrella/glasses/wings) too ;
- For power users: allows redrawing by object index with `/penumbra redraw #n` (`/penumbra redraw #0` is equivalent to `… self`, `/penumbra redraw #1` to redraw just the minion/mount/ornament, and so on)