### PR TITLE
Full resource tree retrieval via IPC

### DIFF
--- a/Penumbra/Api/PenumbraApi.cs
+++ b/Penumbra/Api/PenumbraApi.cs
@@ -1075,6 +1075,15 @@ public class PenumbraApi : IDisposable, IPenumbraApi
         return resDictionaries.AsReadOnly();
     }
 
+    public IEnumerable<Ipc.ResourceNode>?[] GetGameObjectResourceTrees(bool withUIData, params ushort[] gameObjects)
+    {
+        var characters = gameObjects.Select(index => _dalamud.Objects[index]).OfType<Character>();
+        var resourceTrees = _resourceTreeFactory.FromCharacters(characters, withUIData ? ResourceTreeFactory.Flags.WithUiData : 0);
+        var resDictionary = ResourceTreeApiHelper.EncapsulateResourceTrees(resourceTrees);
+
+        return Array.ConvertAll(gameObjects, obj => resDictionary.TryGetValue(obj, out var nodes) ? nodes : null);
+    }
+
 
     // TODO: cleanup when incrementing API
     public string GetMetaManipulations(string characterName)

--- a/Penumbra/Api/PenumbraApi.cs
+++ b/Penumbra/Api/PenumbraApi.cs
@@ -1084,6 +1084,14 @@ public class PenumbraApi : IDisposable, IPenumbraApi
         return Array.ConvertAll(gameObjects, obj => resDictionary.TryGetValue(obj, out var nodes) ? nodes : null);
     }
 
+    public IReadOnlyDictionary<ushort, IEnumerable<Ipc.ResourceNode>> GetPlayerResourceTrees(bool withUIData)
+    {
+        var resourceTrees = _resourceTreeFactory.FromObjectTable(ResourceTreeFactory.Flags.LocalPlayerRelatedOnly
+          | (withUIData ? ResourceTreeFactory.Flags.WithUiData : 0));
+        var resDictionary = ResourceTreeApiHelper.EncapsulateResourceTrees(resourceTrees);
+
+        return resDictionary.AsReadOnly();
+    }
 
     // TODO: cleanup when incrementing API
     public string GetMetaManipulations(string characterName)

--- a/Penumbra/Api/PenumbraApi.cs
+++ b/Penumbra/Api/PenumbraApi.cs
@@ -1075,7 +1075,7 @@ public class PenumbraApi : IDisposable, IPenumbraApi
         return resDictionaries.AsReadOnly();
     }
 
-    public IEnumerable<Ipc.ResourceNode>?[] GetGameObjectResourceTrees(bool withUIData, params ushort[] gameObjects)
+    public Ipc.ResourceTree?[] GetGameObjectResourceTrees(bool withUIData, params ushort[] gameObjects)
     {
         var characters = gameObjects.Select(index => _dalamud.Objects[index]).OfType<Character>();
         var resourceTrees = _resourceTreeFactory.FromCharacters(characters, withUIData ? ResourceTreeFactory.Flags.WithUiData : 0);
@@ -1084,7 +1084,7 @@ public class PenumbraApi : IDisposable, IPenumbraApi
         return Array.ConvertAll(gameObjects, obj => resDictionary.TryGetValue(obj, out var nodes) ? nodes : null);
     }
 
-    public IReadOnlyDictionary<ushort, IEnumerable<Ipc.ResourceNode>> GetPlayerResourceTrees(bool withUIData)
+    public IReadOnlyDictionary<ushort, Ipc.ResourceTree> GetPlayerResourceTrees(bool withUIData)
     {
         var resourceTrees = _resourceTreeFactory.FromObjectTable(ResourceTreeFactory.Flags.LocalPlayerRelatedOnly
           | (withUIData ? ResourceTreeFactory.Flags.WithUiData : 0));

--- a/Penumbra/Api/PenumbraIpcProviders.cs
+++ b/Penumbra/Api/PenumbraIpcProviders.cs
@@ -130,8 +130,8 @@ public class PenumbraIpcProviders : IDisposable
         FuncProvider<ResourceType, bool, IReadOnlyDictionary<ushort, IReadOnlyDictionary<nint, (string, string, ChangedItemIcon)>>>
         GetPlayerResourcesOfType;
 
-    internal readonly FuncProvider<bool, ushort[], IEnumerable<Ipc.ResourceNode>?[]>                    GetGameObjectResourceTrees;
-    internal readonly FuncProvider<bool, IReadOnlyDictionary<ushort, IEnumerable<Ipc.ResourceNode>>>    GetPlayerResourceTrees;
+    internal readonly FuncProvider<bool, ushort[], Ipc.ResourceTree?[]>                         GetGameObjectResourceTrees;
+    internal readonly FuncProvider<bool, IReadOnlyDictionary<ushort, Ipc.ResourceTree>>         GetPlayerResourceTrees;
 
     public PenumbraIpcProviders(DalamudServices dalamud, IPenumbraApi api, ModManager modManager, CollectionManager collections,
         TempModManager tempMods, TempCollectionManager tempCollections, SaveService saveService, Configuration config)

--- a/Penumbra/Api/PenumbraIpcProviders.cs
+++ b/Penumbra/Api/PenumbraIpcProviders.cs
@@ -131,6 +131,7 @@ public class PenumbraIpcProviders : IDisposable
         GetPlayerResourcesOfType;
 
     internal readonly FuncProvider<bool, ushort[], IEnumerable<Ipc.ResourceNode>?[]>                    GetGameObjectResourceTrees;
+    internal readonly FuncProvider<bool, IReadOnlyDictionary<ushort, IEnumerable<Ipc.ResourceNode>>>    GetPlayerResourceTrees;
 
     public PenumbraIpcProviders(DalamudServices dalamud, IPenumbraApi api, ModManager modManager, CollectionManager collections,
         TempModManager tempMods, TempCollectionManager tempCollections, SaveService saveService, Configuration config)
@@ -256,7 +257,8 @@ public class PenumbraIpcProviders : IDisposable
         GetPlayerResourcePaths       = Ipc.GetPlayerResourcePaths.Provider(pi, Api.GetPlayerResourcePaths);
         GetGameObjectResourcesOfType = Ipc.GetGameObjectResourcesOfType.Provider(pi, Api.GetGameObjectResourcesOfType);
         GetPlayerResourcesOfType     = Ipc.GetPlayerResourcesOfType.Provider(pi, Api.GetPlayerResourcesOfType);
-        GetGameObjectResourceTrees = Ipc.GetGameObjectResourceTrees.Provider(pi, Api.GetGameObjectResourceTrees);
+        GetGameObjectResourceTrees   = Ipc.GetGameObjectResourceTrees.Provider(pi, Api.GetGameObjectResourceTrees);
+        GetPlayerResourceTrees       = Ipc.GetPlayerResourceTrees.Provider(pi, Api.GetPlayerResourceTrees);
 
         Tester = new IpcTester(config, dalamud, this, modManager, collections, tempMods, tempCollections, saveService);
 

--- a/Penumbra/Api/PenumbraIpcProviders.cs
+++ b/Penumbra/Api/PenumbraIpcProviders.cs
@@ -130,6 +130,8 @@ public class PenumbraIpcProviders : IDisposable
         FuncProvider<ResourceType, bool, IReadOnlyDictionary<ushort, IReadOnlyDictionary<nint, (string, string, ChangedItemIcon)>>>
         GetPlayerResourcesOfType;
 
+    internal readonly FuncProvider<bool, ushort[], IEnumerable<Ipc.ResourceNode>?[]>                    GetGameObjectResourceTrees;
+
     public PenumbraIpcProviders(DalamudServices dalamud, IPenumbraApi api, ModManager modManager, CollectionManager collections,
         TempModManager tempMods, TempCollectionManager tempCollections, SaveService saveService, Configuration config)
     {
@@ -254,6 +256,7 @@ public class PenumbraIpcProviders : IDisposable
         GetPlayerResourcePaths       = Ipc.GetPlayerResourcePaths.Provider(pi, Api.GetPlayerResourcePaths);
         GetGameObjectResourcesOfType = Ipc.GetGameObjectResourcesOfType.Provider(pi, Api.GetGameObjectResourcesOfType);
         GetPlayerResourcesOfType     = Ipc.GetPlayerResourcesOfType.Provider(pi, Api.GetPlayerResourcesOfType);
+        GetGameObjectResourceTrees = Ipc.GetGameObjectResourceTrees.Provider(pi, Api.GetGameObjectResourceTrees);
 
         Tester = new IpcTester(config, dalamud, this, modManager, collections, tempMods, tempCollections, saveService);
 

--- a/Penumbra/Api/PenumbraIpcProviders.cs
+++ b/Penumbra/Api/PenumbraIpcProviders.cs
@@ -375,6 +375,8 @@ public class PenumbraIpcProviders : IDisposable
         GetPlayerResourcePaths.Dispose();
         GetGameObjectResourcesOfType.Dispose();
         GetPlayerResourcesOfType.Dispose();
+        GetGameObjectResourceTrees.Dispose();
+        GetPlayerResourceTrees.Dispose();
 
         Disposed.Invoke();
         Disposed.Dispose();

--- a/Penumbra/Interop/ResourceTree/ResourceTreeApiHelper.cs
+++ b/Penumbra/Interop/ResourceTree/ResourceTreeApiHelper.cs
@@ -86,7 +86,7 @@ internal static class ResourceTreeApiHelper
                 ActualPath = node.FullPath.ToString(),
                 ObjectAddress = node.ObjectAddress,
                 ResourceHandle = node.ResourceHandle,
-                Children = node.Children.Select(GetIpcNode).ToArray(),
+                Children = node.Children.Select(GetIpcNode).ToList(),
             };
 
         static Ipc.ResourceTree GetIpcTree(ResourceTree tree) =>
@@ -94,7 +94,7 @@ internal static class ResourceTreeApiHelper
             {
                 Name = tree.Name,
                 RaceCode = (ushort)tree.RaceCode,
-                Nodes = tree.Nodes.Select(GetIpcNode).ToArray(),
+                Nodes = tree.Nodes.Select(GetIpcNode).ToList(),
             };
 
         var resDictionary = new Dictionary<ushort, Ipc.ResourceTree>(4);

--- a/Penumbra/Interop/ResourceTree/ResourceTreeApiHelper.cs
+++ b/Penumbra/Interop/ResourceTree/ResourceTreeApiHelper.cs
@@ -76,10 +76,9 @@ internal static class ResourceTreeApiHelper
 
     public static Dictionary<ushort, IEnumerable<Ipc.ResourceNode>> EncapsulateResourceTrees(IEnumerable<(Character, ResourceTree)> resourceTrees)
     {
-        static Ipc.ResourceNode GetIpcNode(ResourceNode[] tree, ResourceNode node) =>
+        static Ipc.ResourceNode GetIpcNode(ResourceNode node) =>
             new()
             {
-                ChildrenIndices = node.Children.Select(c => Array.IndexOf(tree, c)).ToArray(),
                 Type = node.Type,
                 Icon = ChangedItemDrawer.ToApiIcon(node.Icon),
                 Name = node.Name,
@@ -87,13 +86,11 @@ internal static class ResourceTreeApiHelper
                 ActualPath = node.FullPath.ToString(),
                 ObjectAddress = node.ObjectAddress,
                 ResourceHandle = node.ResourceHandle,
+                Children = node.Children.Select(GetIpcNode).ToArray(),
             };
 
-        static IEnumerable<Ipc.ResourceNode> GetIpcNodes(ResourceTree tree)
-        {
-            var nodes = tree.FlatNodes.ToArray();
-            return nodes.Select(n => GetIpcNode(nodes, n)).ToArray();
-        }
+        static IEnumerable<Ipc.ResourceNode> GetIpcNodes(ResourceTree tree) =>
+            tree.Nodes.Select(GetIpcNode).ToArray();
 
         var resDictionary = new Dictionary<ushort, IEnumerable<Ipc.ResourceNode>>(4);
         foreach (var (gameObject, resourceTree) in resourceTrees)

--- a/Penumbra/Interop/ResourceTree/ResourceTreeApiHelper.cs
+++ b/Penumbra/Interop/ResourceTree/ResourceTreeApiHelper.cs
@@ -74,7 +74,7 @@ internal static class ResourceTreeApiHelper
                 pair => (IReadOnlyDictionary<nint, (string, string, ChangedItemIcon)>)pair.Value.AsReadOnly());
     }
 
-    public static Dictionary<ushort, IEnumerable<Ipc.ResourceNode>> EncapsulateResourceTrees(IEnumerable<(Character, ResourceTree)> resourceTrees)
+    public static Dictionary<ushort, Ipc.ResourceTree> EncapsulateResourceTrees(IEnumerable<(Character, ResourceTree)> resourceTrees)
     {
         static Ipc.ResourceNode GetIpcNode(ResourceNode node) =>
             new()
@@ -89,16 +89,21 @@ internal static class ResourceTreeApiHelper
                 Children = node.Children.Select(GetIpcNode).ToArray(),
             };
 
-        static IEnumerable<Ipc.ResourceNode> GetIpcNodes(ResourceTree tree) =>
-            tree.Nodes.Select(GetIpcNode).ToArray();
+        static Ipc.ResourceTree GetIpcTree(ResourceTree tree) =>
+            new()
+            {
+                Name = tree.Name,
+                RaceCode = (ushort)tree.RaceCode,
+                Nodes = tree.Nodes.Select(GetIpcNode).ToArray(),
+            };
 
-        var resDictionary = new Dictionary<ushort, IEnumerable<Ipc.ResourceNode>>(4);
+        var resDictionary = new Dictionary<ushort, Ipc.ResourceTree>(4);
         foreach (var (gameObject, resourceTree) in resourceTrees)
         {
             if (resDictionary.ContainsKey(gameObject.ObjectIndex))
                 continue;
 
-            resDictionary.Add(gameObject.ObjectIndex, GetIpcNodes(resourceTree));
+            resDictionary.Add(gameObject.ObjectIndex, GetIpcTree(resourceTree));
         }
 
         return resDictionary;


### PR DESCRIPTION
Implementation of Ottermandias/Penumbra.Api#2.

Adds the ability for a plugin to access the full resource tree of any game object instead of only being able to access specific resources or resource paths.

Docs (in `IPenumbraApi`):

<details><summary>GetGameObjectResourceTrees</summary>

```csharp
/// <summary>
/// Get the given game objects' resource tree.
/// </summary>
/// <param name="withUIData"> Whether to get names and icons along with the paths. </param>
/// <param name="gameObjects"> The game object indices for which to get the resources. </param>
/// <returns> An array of resource trees, of the same length and in the same order as the given game object index array. </returns>
/// <remarks>
/// It is the caller's responsibility to make sure the returned resource handles are still in use on the game object's draw object before using them. <para />
/// Also, callers should not use UI data for non-UI purposes.
/// </remarks>
public IEnumerable<Ipc.ResourceNode>?[] GetGameObjectResourceTrees(bool withUIData, params ushort[] gameObjects);
```
</details>

<details><summary>GetPlayerResourceTrees</summary>

```csharp
/// <summary>
/// Get the player and player-owned game objects' resource trees.
/// </summary>
/// <param name="withUIData"> Whether to get names and icons along with the paths. </param>
/// <returns> A dictionary of game object indices to resource trees. </returns>
/// <remarks>
/// It is the caller's responsibility to make sure the returned resource handles are still in use on the game object's draw object before using them. <para />
/// Also, callers should not use UI data for non-UI purposes.
/// </remarks>
public IReadOnlyDictionary<ushort, IEnumerable<Ipc.ResourceNode>> GetPlayerResourceTrees(bool withUIData);
```
</details>