### PR TITLE
Check Wine file system sanity

### DIFF
--- a/Penumbra/Penumbra.cs
+++ b/Penumbra/Penumbra.cs
@@ -282,7 +282,7 @@ public class Penumbra : IDalamudPlugin
             var value = Environment.GetEnvironmentVariable(variableToCheck);
             if (!string.IsNullOrEmpty(value))
             {
-                return value.EndsWith(".UTF-8", StringComparison.OrdinalIgnoreCase)
+                return value.EndsWith(".UTF-8", StringComparison.OrdinalIgnoreCase) || value.EndsWith(".utf8", StringComparison.OrdinalIgnoreCase)
                     ? (true,  string.Empty)
                     : (false, variableToSet);
             }

--- a/Penumbra/UI/Tabs/SettingsTab.cs
+++ b/Penumbra/UI/Tabs/SettingsTab.cs
@@ -213,7 +213,7 @@ public class SettingsTab : ITab
         if (isSane)
             return;
 
-        var tooltip = $"Please run XIVLauncher with a UTF-8 locale, for example by setting the following environment variable:\n\n{variableToSet}=C.UTF-8";
+        var tooltip = $"Your current configuration may cause problems with Unicode characters in mods. For the best experience, please configure Wine to use UTF-8 file paths for the game. This can be achieved by passing the following environment variable to XIVLauncher, for example:\n\n{variableToSet}=C.UTF-8";
 
         ImGui.SetCursorPosX(ImGui.GetCursorPosX() - 1.0f - ImGui.GetStyle().ItemSpacing.X);
         ImGui.Dummy(new Vector2(1.0f));
@@ -221,7 +221,7 @@ public class SettingsTab : ITab
         ImGui.SameLine();
         using (var _ = ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed))
         {
-            ImGui.TextUnformatted("Your XIVLauncher is misconfigured, which can cause issues with special characters in mods.");
+            ImGui.TextUnformatted("For the best experience, please configure Wine to use UTF-8 file paths.");
         }
         ImGuiUtil.HoverTooltip(tooltip);
     }

--- a/Penumbra/UI/Tabs/SettingsTab.cs
+++ b/Penumbra/UI/Tabs/SettingsTab.cs
@@ -1,4 +1,5 @@
 using Dalamud.Interface;
+using Dalamud.Interface.Colors;
 using Dalamud.Interface.Components;
 using Dalamud.Utility;
 using ImGuiNET;
@@ -84,6 +85,7 @@ public class SettingsTab : ITab
         ImGui.NewLine();
         DrawRootFolder();
         DrawDirectoryButtons();
+        DrawFileSystemWarningIfNeeded();
         ImGui.NewLine();
 
         DrawGeneralSettings();
@@ -203,6 +205,25 @@ public class SettingsTab : ITab
                 : ".";
 
         _fileDialog.OpenFolderPicker("Choose Mod Directory", (b, s) => _newModDirectory = b ? s : _newModDirectory, startDir, false);
+    }
+
+    private static void DrawFileSystemWarningIfNeeded()
+    {
+        var (isSane, variableToSet) = Penumbra.IsFileSystemSane();
+        if (isSane)
+            return;
+
+        var tooltip = $"Please run XIVLauncher with a UTF-8 locale, for example by setting the following environment variable:\n\n{variableToSet}=C.UTF-8";
+
+        ImGui.SetCursorPosX(ImGui.GetCursorPosX() - 1.0f - ImGui.GetStyle().ItemSpacing.X);
+        ImGui.Dummy(new Vector2(1.0f));
+        ImGuiComponents.HelpMarker(tooltip);
+        ImGui.SameLine();
+        using (var _ = ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed))
+        {
+            ImGui.TextUnformatted("Your XIVLauncher is misconfigured, which can cause issues with special characters in mods.");
+        }
+        ImGuiUtil.HoverTooltip(tooltip);
     }
 
     /// <summary>


### PR DESCRIPTION
On Wine, this will check the environment variables that control whether the file system handles Unicode sanely.

If they're misconfigured, the following will be displayed on the Settings tab:
![image](https://github.com/xivdev/Penumbra/assets/2236342/a57c980e-b52a-4c7b-a877-f020894d9055)
![image](https://github.com/xivdev/Penumbra/assets/2236342/d86a42fe-17f2-4873-9cc5-e14d757063d0)

See also #350.