### PR TITLE
.mdl attribute editor

### DIFF
--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
@@ -1,3 +1,5 @@
+using System.Collections.ObjectModel;
+using OtterGui;
 using Penumbra.GameData.Files;
 
 namespace Penumbra.UI.AdvancedWindow;
@@ -8,9 +10,94 @@ public partial class ModEditWindow
     {
         public readonly MdlFile Mdl;
 
+        private List<string> _materials;
+        private List<string>[] _attributes;
+
         public MdlTab(byte[] bytes)
         {
             Mdl = new MdlFile(bytes);
+
+            _materials = Mdl.Meshes.Select(mesh => Mdl.Materials[mesh.MaterialIndex]).ToList();
+            _attributes = HydrateAttributes(Mdl);
+        }
+
+        private List<string>[] HydrateAttributes(MdlFile mdl)
+        {
+            return mdl.SubMeshes.Select(submesh => 
+                Enumerable.Range(0,32)
+                    .Where(index => ((submesh.AttributeIndexMask >> index) & 1) == 1)
+                    .Select(index => mdl.Attributes[index])
+                    .ToList()
+            ).ToArray();
+        }
+
+        public string GetMeshMaterial(int meshIndex) => _materials[meshIndex];
+
+        public void SetMeshMaterial(int meshIndex, string materialPath)
+        {
+            _materials[meshIndex] = materialPath;
+
+            PersistMaterials();
+        }
+
+        private void PersistMaterials()
+        {
+            var allMaterials = new List<string>();
+
+            foreach (var (material, meshIndex) in _materials.WithIndex())
+            {
+                var materialIndex = allMaterials.IndexOf(material);
+                if (materialIndex == -1)
+                {
+                    allMaterials.Add(material);
+                    materialIndex = allMaterials.Count() - 1;
+                }
+
+                Mdl.Meshes[meshIndex].MaterialIndex = (ushort)materialIndex;
+            }
+
+            Mdl.Materials = allMaterials.ToArray();
+        }
+
+        public IReadOnlyCollection<string> GetSubmeshAttributes(int submeshIndex) => _attributes[submeshIndex]; 
+
+        public void UpdateSubmeshAttribute(int submeshIndex, string? old, string? new_)
+        {
+            var attributes = _attributes[submeshIndex];
+
+            if (old != null)
+                attributes.Remove(old);
+
+            if (new_ != null)
+                attributes.Add(new_);
+
+            PersistAttributes();
+        }
+
+        private void PersistAttributes()
+        {
+            var allAttributes = new List<string>();
+
+            foreach (var (attributes, submeshIndex) in _attributes.WithIndex())
+            {
+                var mask = 0u;
+
+                foreach (var attribute in attributes)
+                {
+                    var attributeIndex = allAttributes.IndexOf(attribute);
+                    if (attributeIndex == -1)
+                    {
+                        allAttributes.Add(attribute);
+                        attributeIndex = allAttributes.Count() - 1;
+                    }
+
+                    mask |= 1u << attributeIndex;
+                }
+
+                Mdl.SubMeshes[submeshIndex].AttributeIndexMask = mask;
+            }
+
+            Mdl.Attributes = allAttributes.ToArray();
         }
 
         public bool Valid => Mdl.Valid;

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using OtterGui;
 using Penumbra.GameData;
 using Penumbra.GameData.Files;
@@ -24,11 +23,13 @@ public partial class ModEditWindow
             // Meshes using the removed material are redirected to material 0, and those after the index are corrected.
             for (var meshIndex = 0; meshIndex < Mdl.Meshes.Length; meshIndex++)
             {
-                var mesh = Mdl.Meshes[meshIndex];
-                if (mesh.MaterialIndex == materialIndex)
-                    mesh.MaterialIndex = 0;
-                else if (mesh.MaterialIndex > materialIndex)
-                    mesh.MaterialIndex -= 1;
+                var newIndex = Mdl.Meshes[meshIndex].MaterialIndex;
+                if (newIndex == materialIndex)
+                    newIndex = 0;
+                else if (newIndex > materialIndex)
+                    newIndex -= 1;
+
+                Mdl.Meshes[meshIndex].MaterialIndex = newIndex;
             }
 
             Mdl.Materials = Mdl.Materials.RemoveItems(materialIndex);

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
@@ -1,0 +1,20 @@
+using Penumbra.GameData.Files;
+
+namespace Penumbra.UI.AdvancedWindow;
+
+public partial class ModEditWindow
+{
+    private class MdlTab : IWritable
+    {
+        public readonly MdlFile Mdl;
+
+        public MdlTab(byte[] bytes)
+        {
+            Mdl = new MdlFile(bytes);
+        }
+
+        public bool Valid => Mdl.Valid;
+
+        public byte[] Write() => Mdl.Write();
+    }
+}

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -58,35 +58,32 @@ public partial class ModEditWindow
 
         // Submeshes.
         for (var submeshOffset = 0; submeshOffset < mesh.SubMeshCount; submeshOffset++)
-            ret |= DrawSubMeshDetails(file, mesh.SubMeshIndex + submeshOffset, disabled);
-
-        return ret;
-    }
-
-    private static bool DrawSubMeshDetails(MdlFile file, int submeshIndex, bool disabled)
-    {
-        using var id = ImRaii.PushId(submeshIndex);
-
-        var submesh = file.SubMeshes[submeshIndex];
-        var widget = _submeshAttributeTagWidgets[submeshIndex];
-
-        var attributes = HydrateAttributes(file, submesh.AttributeIndexMask).ToArray();
-
-        UiHelpers.DefaultLineSpace();
-        var tagIndex = widget.Draw($"Submesh {submeshIndex} Attributes", "", attributes, out var editedAttribute, !disabled);
-        if (tagIndex >= 0)
         {
-            EditSubmeshAttribute(
-                file,
-                submeshIndex,
-                tagIndex < attributes.Length ? attributes[tagIndex] : null,
-                editedAttribute != "" ? editedAttribute : null
-            );
+            using var submeshId = ImRaii.PushId(submeshOffset);
 
-            return true;
+            var submeshIndex = mesh.SubMeshIndex + submeshOffset;
+
+            var submesh = file.SubMeshes[submeshIndex];
+            var widget = _submeshAttributeTagWidgets[submeshIndex];
+
+            var attributes = HydrateAttributes(file, submesh.AttributeIndexMask).ToArray();
+
+            UiHelpers.DefaultLineSpace();
+            var tagIndex = widget.Draw($"Submesh {submeshOffset} Attributes", "", attributes, out var editedAttribute, !disabled);
+            if (tagIndex >= 0)
+            {
+                EditSubmeshAttribute(
+                    file,
+                    submeshIndex,
+                    tagIndex < attributes.Length ? attributes[tagIndex] : null,
+                    editedAttribute != "" ? editedAttribute : null
+                );
+
+                ret = true;
+            }
         }
 
-        return false;
+        return ret;
     }
 
     private static void EditSubmeshAttribute(MdlFile file, int changedSubmeshIndex, string? old, string? new_)

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -28,8 +28,9 @@ public partial class ModEditWindow
 
         var ret = false;
 
-        for (var i = 0; i < file.Meshes.Length; ++i)
-            ret |= DrawMeshDetails(tab, i, disabled);
+        if (ImGui.CollapsingHeader($"{file.Meshes.Length} Meshes###meshes"))
+            for (var i = 0; i < file.Meshes.Length; ++i)
+                ret |= DrawMeshDetails(tab, i, disabled);
 
         ret |= DrawOtherModelDetails(file, disabled);
 
@@ -38,7 +39,8 @@ public partial class ModEditWindow
 
     private static bool DrawMeshDetails(MdlTab tab, int meshIndex, bool disabled)
     {
-        if (!ImGui.CollapsingHeader($"Mesh {meshIndex}"))
+        using var meshNode = ImRaii.TreeNode($"Mesh {meshIndex}", ImGuiTreeNodeFlags.DefaultOpen);
+        if (!meshNode)
             return false;
 
         using var id = ImRaii.PushId(meshIndex); 

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -158,27 +158,28 @@ public partial class ModEditWindow
 
         var ret = false;
 
-        // Mesh material.
-        // var temp = tab.GetMeshMaterial(meshIndex);
-        // if (
-        //     ImGui.InputText("Material", ref temp, Utf8GamePath.MaxGamePathLength, disabled ? ImGuiInputTextFlags.ReadOnly : ImGuiInputTextFlags.None)
-        //     && temp.Length > 0
-        //     && temp != tab.GetMeshMaterial(meshIndex)
-        // ) {
-        //     tab.SetMeshMaterial(meshIndex, temp);
-        //     ret = true;
-        // }
+        // Mesh material
         ImGui.TableNextColumn();
         ImGui.Text("Material");
 
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(-1);
-        using (var materialCombo = ImRaii.Combo("##material", "TODO material"))
+        using (var materialCombo = ImRaii.Combo("##material", tab.Mdl.Materials[mesh.MaterialIndex]))
         {
-            // todo
+            if (materialCombo)
+            {
+                foreach (var (material, materialIndex) in tab.Mdl.Materials.WithIndex())
+                {
+                    if (ImGui.Selectable(material, mesh.MaterialIndex == materialIndex))
+                    {
+                        file.Meshes[meshIndex].MaterialIndex = (ushort)materialIndex;
+                        ret = true;
+                    }
+                }
+            }
         }
 
-        // Submeshes.
+        // Submeshes
         for (var submeshOffset = 0; submeshOffset < mesh.SubMeshCount; submeshOffset++)
         {
             using var submeshId = ImRaii.PushId(submeshOffset);

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -135,6 +135,13 @@ public partial class ModEditWindow
             }
         }
 
+        using (var materials = ImRaii.TreeNode("Materials", ImGuiTreeNodeFlags.DefaultOpen))
+        {
+            if (materials)
+                foreach (var material in file.Materials)
+                    ImRaii.TreeNode(material, ImGuiTreeNodeFlags.Leaf).Dispose();
+        }
+
         using (var attributes = ImRaii.TreeNode("Attributes", ImGuiTreeNodeFlags.DefaultOpen))
         {
             if (attributes)

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -9,12 +9,14 @@ namespace Penumbra.UI.AdvancedWindow;
 
 public partial class ModEditWindow
 {
-    private readonly FileEditor<MdlFile> _modelTab;
+    private readonly FileEditor<MdlTab> _modelTab;
 
     private static List<TagButtons> _submeshAttributeTagWidgets = new();
 
-    private static bool DrawModelPanel(MdlFile file, bool disabled)
+    private static bool DrawModelPanel(MdlTab tab, bool disabled)
     {
+        var file = tab.Mdl;
+
         var submeshTotal = file.Meshes.Aggregate(0, (count, mesh) => count + mesh.SubMeshCount);
         if (_submeshAttributeTagWidgets.Count != submeshTotal)
         {

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -1,9 +1,7 @@
 using ImGuiNET;
-using Lumina.Excel.GeneratedSheets;
 using OtterGui;
 using OtterGui.Raii;
 using OtterGui.Widgets;
-using Penumbra.GameData;
 using Penumbra.GameData.Files;
 using Penumbra.String.Classes;
 

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -28,13 +28,29 @@ public partial class ModEditWindow
 
         var ret = false;
 
-        if (ImGui.CollapsingHeader($"{file.Meshes.Length} Meshes###meshes"))
-            for (var i = 0; i < file.Meshes.Length; ++i)
-                ret |= DrawMeshDetails(tab, i, disabled);
+        if (ImGui.CollapsingHeader($"Meshes ({file.Meshes.Length})###meshes"))
+            for (var i = 0; i < file.LodCount; ++i)
+                ret |= DrawLodDetails(tab, i, disabled);
 
         ret |= DrawOtherModelDetails(file, disabled);
 
         return !disabled && ret;
+    }
+
+    private static bool DrawLodDetails(MdlTab tab, int lodIndex, bool disabled)
+    {
+        using var lodNode = ImRaii.TreeNode($"LOD {lodIndex}", ImGuiTreeNodeFlags.DefaultOpen);
+        if (!lodNode)
+            return false;
+
+        var lod = tab.Mdl.Lods[lodIndex];
+
+        var ret = false;
+
+        for (var meshOffset = 0; meshOffset < lod.MeshCount; meshOffset++)
+            ret |= DrawMeshDetails(tab, lod.MeshIndex + meshOffset, disabled);
+
+        return ret;
     }
 
     private static bool DrawMeshDetails(MdlTab tab, int meshIndex, bool disabled)

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.cs
@@ -584,8 +584,8 @@ public partial class ModEditWindow : Window, IDisposable
         _materialTab = new FileEditor<MtrlTab>(this, gameData, config, _editor.Compactor, _fileDialog, "Materials", ".mtrl",
             () => PopulateIsOnPlayer(_editor.Files.Mtrl, ResourceType.Mtrl), DrawMaterialPanel, () => _mod?.ModPath.FullName ?? string.Empty,
             (bytes, path, writable) => new MtrlTab(this, new MtrlFile(bytes), path, writable));
-        _modelTab = new FileEditor<MdlFile>(this, gameData, config, _editor.Compactor, _fileDialog, "Models", ".mdl",
-            () => PopulateIsOnPlayer(_editor.Files.Mdl, ResourceType.Mdl), DrawModelPanel, () => _mod?.ModPath.FullName ?? string.Empty, (bytes, _, _) => new MdlFile(bytes));
+        _modelTab = new FileEditor<MdlTab>(this, gameData, config, _editor.Compactor, _fileDialog, "Models", ".mdl",
+            () => PopulateIsOnPlayer(_editor.Files.Mdl, ResourceType.Mdl), DrawModelPanel, () => _mod?.ModPath.FullName ?? string.Empty, (bytes, _, _) => new MdlTab(bytes));
         _shaderPackageTab = new FileEditor<ShpkTab>(this, gameData, config, _editor.Compactor, _fileDialog, "Shaders", ".shpk",
             () => PopulateIsOnPlayer(_editor.Files.Shpk, ResourceType.Shpk), DrawShaderPackagePanel, () => _mod?.ModPath.FullName ?? string.Empty,
             (bytes, _, _) => new ShpkTab(_fileDialog, bytes));


### PR DESCRIPTION
Adds the ability to edit attributes in the existing .mdl tab in advanced editing.
Also moves the existing material fields into per-mesh headers to mimic how they're used in-game.


https://github.com/xivdev/Penumbra/assets/534235/cb48b8fe-19d6-4fc9-9654-49ed278cbe7d