### PR TITLE
Export: Add support for EST-resolved skeletons

### DIFF
--- a/Penumbra/Import/Models/Export/ModelExporter.cs
+++ b/Penumbra/Import/Models/Export/ModelExporter.cs
@@ -22,7 +22,7 @@ public class ModelExporter
     }
 
     /// <summary> Export a model in preparation for usage in a glTF file. If provided, skeleton will be used to skin the resulting meshes where appropriate. </summary>
-    public static Model Export(MdlFile mdl, XivSkeleton? xivSkeleton)
+    public static Model Export(MdlFile mdl, IEnumerable<XivSkeleton>? xivSkeleton)
     {
         var gltfSkeleton = xivSkeleton != null ? ConvertSkeleton(xivSkeleton) : null;
         var meshes = ConvertMeshes(mdl, gltfSkeleton);
@@ -50,12 +50,15 @@ public class ModelExporter
     }
 
     /// <summary> Convert XIV skeleton data into a glTF-compatible node tree, with mappings. </summary>
-    private static GltfSkeleton? ConvertSkeleton(XivSkeleton skeleton)
+    private static GltfSkeleton? ConvertSkeleton(IEnumerable<XivSkeleton> skeletons)
     {
         NodeBuilder? root = null;
         var names = new Dictionary<string, int>();
         var joints = new List<NodeBuilder>();
-        foreach (var bone in skeleton.Bones)
+
+        // Flatten out the bones across all the recieved skeletons, but retain a reference to the parent skeleton for lookups.
+        var iterator = skeletons.SelectMany(skeleton => skeleton.Bones.Select(bone => (skeleton, bone)));
+        foreach (var (skeleton, bone) in iterator)
         {
             if (names.ContainsKey(bone.Name)) continue;
 

--- a/Penumbra/Import/Models/ModelManager.cs
+++ b/Penumbra/Import/Models/ModelManager.cs
@@ -49,7 +49,7 @@ public sealed class ModelManager(IFramework framework, ActiveCollections collect
             ObjectType.Character when info.BodySlot is BodySlot.Body or BodySlot.Tail => [baseSkeleton],
             ObjectType.Character when info.BodySlot is BodySlot.Hair
                 => [baseSkeleton, ResolveEstSkeleton(EstManipulation.EstType.Hair, info, estManipulations)],
-            ObjectType.Character when info.BodySlot is BodySlot.Face
+            ObjectType.Character when info.BodySlot is BodySlot.Face or BodySlot.Ear
                 => [baseSkeleton, ResolveEstSkeleton(EstManipulation.EstType.Face, info, estManipulations)],
             ObjectType.Character => throw new Exception($"Currently unsupported human model type \"{info.BodySlot}\"."),
             ObjectType.DemiHuman => [GamePaths.DemiHuman.Sklb.Path(info.PrimaryId)],
@@ -75,7 +75,7 @@ public sealed class ModelManager(IFramework framework, ActiveCollections collect
             ?? collections.Current.MetaCache?.GetEstEntry(type, info.GenderRace, info.PrimaryId)
             ?? info.PrimaryId;
 
-        return GamePaths.Skeleton.Sklb.Path(info.GenderRace, info.BodySlot.ToSuffix(), targetId);
+        return GamePaths.Skeleton.Sklb.Path(info.GenderRace, EstManipulation.ToName(type), targetId);
     }
 
     private Task Enqueue(IAction action)

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.cs
@@ -600,7 +600,7 @@ public partial class ModEditWindow : Window, IDisposable
             (bytes, path, writable) => new MtrlTab(this, new MtrlFile(bytes), path, writable));
         _modelTab = new FileEditor<MdlTab>(this, gameData, config, _editor.Compactor, _fileDialog, "Models", ".mdl",
             () => PopulateIsOnPlayer(_editor.Files.Mdl, ResourceType.Mdl), DrawModelPanel, () => _mod?.ModPath.FullName ?? string.Empty,
-            (bytes, path, _) => new MdlTab(this, bytes, path, _mod));
+            (bytes, path, _) => new MdlTab(this, bytes, path));
         _shaderPackageTab = new FileEditor<ShpkTab>(this, gameData, config, _editor.Compactor, _fileDialog, "Shaders", ".shpk",
             () => PopulateIsOnPlayer(_editor.Files.Shpk, ResourceType.Shpk), DrawShaderPackagePanel,
             () => _mod?.ModPath.FullName ?? string.Empty,


### PR DESCRIPTION
requires https://github.com/Ottermandias/Penumbra.GameData/pull/12 for viera support.

this pr:
- updates model export code slightly to merge multiple `XivSkeleton`s when building the `GltfSkeleton`
- updates `SklbFile` -> `XivSkeleton` conversion to not crash if you do too much at once
- adds est-driven sklb resolution for body and head equipment, as well as hair/face/viera ear human parts.