### PR TITLE
.mdl io: improve error messaging

### DIFF
--- a/Penumbra/Import/Models/Import/ModelImporter.cs
+++ b/Penumbra/Import/Models/Import/ModelImporter.cs
@@ -4,7 +4,7 @@ using SharpGLTF.Schema2;
 
 namespace Penumbra.Import.Models.Import;
 
-public partial class ModelImporter(ModelRoot _model)
+public partial class ModelImporter(ModelRoot model)
 {
     public static MdlFile Import(ModelRoot model)
     {
@@ -99,7 +99,7 @@ public partial class ModelImporter(ModelRoot _model)
 
     /// <summary> Returns an iterator over sorted, grouped mesh nodes. </summary>
     private IEnumerable<IEnumerable<Node>> GroupedMeshNodes()
-        => _model.LogicalNodes
+        => model.LogicalNodes
             .Where(node => node.Mesh != null)
             .Select(node =>
             {
@@ -171,6 +171,14 @@ public partial class ModelImporter(ModelRoot _model)
 
             _shapeValues.AddRange(meshShapeKey.ShapeValues);
         }
+
+        // The number of shape values in a model is bounded by the count
+        // value, which is stored as a u16.
+        // While technically there are similar bounds on other shape struct
+        // arrays, values is practically guaranteed to be the highest of the
+        // group, so a failure on any of them will be a failure on it.
+        if (_shapeValues.Count > ushort.MaxValue)
+            throw new Exception($"Importing this file would require more than the maximum of {ushort.MaxValue} shape values.\nTry removing or applying shape keys that do not need to be changed at runtime in-game.");
     }
 
     private ushort BuildBoneTable(List<string> boneNames)

--- a/Penumbra/Import/Models/ModelManager.cs
+++ b/Penumbra/Import/Models/ModelManager.cs
@@ -37,7 +37,12 @@ public sealed class ModelManager(IFramework framework, ActiveCollections collect
     public Task<MdlFile?> ImportGltf(string inputPath)
     {
         var action = new ImportGltfAction(inputPath);
-        return Enqueue(action).ContinueWith(_ => action.Out);
+        return Enqueue(action).ContinueWith(task => 
+        {
+            if (task.IsFaulted && task.Exception != null)
+                throw task.Exception;
+            return action.Out;
+        });
     }
     /// <summary> Try to find the .sklb paths for a .mdl file. </summary>
     /// <param name="mdlPath"> .mdl file to look up the skeletons for. </param>

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -138,7 +138,7 @@ public partial class ModEditWindow
         var spaceAvail = ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X - 100;
         foreach (var exception in tab.IoExceptions)
         {
-            var message = $"{exception.GetType().Name}: {exception.Message} {exception.Message}";
+            var message = $"{exception.GetType().Name}: {exception.Message}";
             var textSize = ImGui.CalcTextSize(message).X;
             if (textSize > spaceAvail)
                 message = message.Substring(0, (int)Math.Floor(message.Length * (spaceAvail / textSize))) + "...";

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -7,6 +7,7 @@ using Penumbra.GameData;
 using Penumbra.GameData.Files;
 using Penumbra.Import.Models;
 using Penumbra.String.Classes;
+using Penumbra.UI.Classes;
 
 namespace Penumbra.UI.AdvancedWindow;
 
@@ -61,8 +62,7 @@ public partial class ModEditWindow
         ImGui.SameLine();
         DrawExport(tab, childSize, disabled);
 
-        if (tab.IoException != null)
-            ImGuiUtil.TextWrapped(tab.IoException);
+        DrawIoExceptions(tab);
     }
 
     private void DrawImport(MdlTab tab, Vector2 size, bool _1)
@@ -99,10 +99,10 @@ public partial class ModEditWindow
 
         if (tab.GamePaths == null)
         {
-            if (tab.IoException == null)
+            if (tab.IoExceptions.Count == 0)
                 ImGui.TextUnformatted("Resolving model game paths.");
             else
-                ImGuiUtil.TextWrapped(tab.IoException);
+                ImGui.TextUnformatted("Failed to resolve model game paths.");
 
             return;
         }
@@ -125,6 +125,30 @@ public partial class ModEditWindow
                 _mod!.ModPath.FullName,
                 false
             );
+    }
+    
+    private void DrawIoExceptions(MdlTab tab)
+    {
+        if (tab.IoExceptions.Count == 0)
+            return;
+
+        var size = new Vector2(ImGui.GetContentRegionAvail().X, 0);
+        using var frame = ImRaii.FramedGroup("Exceptions", size, headerPreIcon: FontAwesomeIcon.TimesCircle, borderColor: Colors.RegexWarningBorder);
+
+        var spaceAvail = ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X - 100;
+        foreach (var exception in tab.IoExceptions)
+        {
+            var message = $"{exception.GetType().Name}: {exception.Message} {exception.Message}";
+            var textSize = ImGui.CalcTextSize(message).X;
+            if (textSize > spaceAvail)
+                message = message.Substring(0, (int)Math.Floor(message.Length * (spaceAvail / textSize))) + "...";
+
+            using (var exceptionNode = ImRaii.TreeNode(message))
+            {
+                if (exceptionNode)
+                    ImGuiUtil.TextWrapped(exception.ToString());
+            }
+        }
     }
 
     private void DrawGamePathCombo(MdlTab tab)


### PR DESCRIPTION
hit some errors in import and realised that import errors were being squashed by the intermediary `ContinueWith` task, so i'm checking + rethrowing them if found.

that was also causing a bunch of aggregate error nesting, so i've fleshed out the io exception handling a bit to flatten aggregates when it receives one, and draw them in a nice box for nicer presentation

big thamk to otter for adding the border controls

**default view**
![image](https://github.com/xivdev/Penumbra/assets/534235/ce47abd7-1d32-446c-9645-917d48ee72e5)
**expanded**
![image](https://github.com/xivdev/Penumbra/assets/534235/1574cfb0-230d-49e2-bbcf-3555bb1a7c20)
