### PR TITLE
.mdl io: Import and export names of materials and attributes.

### DIFF
--- a/Penumbra/Import/Models/Export/MeshExporter.cs
+++ b/Penumbra/Import/Models/Export/MeshExporter.cs
@@ -13,18 +13,29 @@ namespace Penumbra.Import.Models.Export;
 
 public class MeshExporter
 {
-    public class Mesh(IEnumerable<IMeshBuilder<MaterialBuilder>> meshes, NodeBuilder[]? joints)
+    public class Mesh(IEnumerable<MeshData> meshes, NodeBuilder[]? joints)
     {
         public void AddToScene(SceneBuilder scene)
         {
-            foreach (var mesh in meshes)
+            foreach (var data in meshes)
             {
-                if (joints == null)
-                    scene.AddRigidMesh(mesh, Matrix4x4.Identity);
-                else
-                    scene.AddSkinnedMesh(mesh, Matrix4x4.Identity, joints);
+                var instance = joints != null
+                    ? scene.AddSkinnedMesh(data.Mesh, Matrix4x4.Identity, joints)
+                    : scene.AddRigidMesh(data.Mesh, Matrix4x4.Identity);
+
+                var extras = new Dictionary<string, object>();
+                foreach (var attribute in data.Attributes)
+                    extras.Add(attribute, true);
+
+                instance.WithExtras(JsonContent.CreateFrom(extras));
             }
         }
+    }
+
+    public struct MeshData
+    {
+        public IMeshBuilder<MaterialBuilder> Mesh;
+        public string[]                      Attributes;
     }
 
     public static Mesh Export(MdlFile mdl, byte lod, ushort meshIndex, MaterialBuilder[] materials, GltfSkeleton? skeleton)
@@ -103,31 +114,33 @@ public class MeshExporter
     }
 
     /// <summary> Build glTF meshes for this XIV mesh. </summary>
-    private IMeshBuilder<MaterialBuilder>[] BuildMeshes()
+    private MeshData[] BuildMeshes()
     {
         var indices  = BuildIndices();
         var vertices = BuildVertices();
 
         // NOTE: Index indices are specified relative to the LOD's 0, but we're reading chunks for each mesh, so we're specifying the index base relative to the mesh's base.
         if (XivMesh.SubMeshCount == 0)
-            return [BuildMesh($"mesh {_meshIndex}", indices, vertices, 0, (int)XivMesh.IndexCount)];
+            return [BuildMesh($"mesh {_meshIndex}", indices, vertices, 0, (int)XivMesh.IndexCount, 0)];
 
         return _mdl.SubMeshes
             .Skip(XivMesh.SubMeshIndex)
             .Take(XivMesh.SubMeshCount)
             .WithIndex()
             .Select(subMesh => BuildMesh($"mesh {_meshIndex}.{subMesh.Index}", indices, vertices,
-                (int)(subMesh.Value.IndexOffset - XivMesh.StartIndex),         (int)subMesh.Value.IndexCount))
+                (int)(subMesh.Value.IndexOffset - XivMesh.StartIndex), (int)subMesh.Value.IndexCount,
+                subMesh.Value.AttributeIndexMask))
             .ToArray();
     }
 
     /// <summary> Build a mesh from the provided indices and vertices. A subset of the full indices may be built by providing an index base and count. </summary>
-    private IMeshBuilder<MaterialBuilder> BuildMesh(
+    private MeshData BuildMesh(
         string name,
         IReadOnlyList<ushort> indices,
         IReadOnlyList<IVertexBuilder> vertices,
         int indexBase,
-        int indexCount
+        int indexCount,
+        uint attributeMask
     )
     {
         var meshBuilderType = typeof(MeshBuilder<,,,>).MakeGenericType(
@@ -190,12 +203,23 @@ public class MeshExporter
             }
         }
 
+        // Named morph targets aren't part of the specification, however `MESH.extras.targetNames`
+        // is a commonly-accepted means of providing the data.
         meshBuilder.Extras = JsonContent.CreateFrom(new Dictionary<string, object>()
         {
             { "targetNames", shapeNames },
         });
 
-        return meshBuilder;
+        var attributes = Enumerable.Range(0, 32)
+            .Where(index => ((attributeMask >> index) & 1) == 1)
+            .Select(index => _mdl.Attributes[index])
+            .ToArray();
+
+        return new MeshData
+        {
+            Mesh = meshBuilder,
+            Attributes = attributes,
+        };
     }
 
     /// <summary> Read in the indices for this mesh. </summary>

--- a/Penumbra/Import/Models/Import/MeshImporter.cs
+++ b/Penumbra/Import/Models/Import/MeshImporter.cs
@@ -10,6 +10,8 @@ public class MeshImporter(IEnumerable<Node> nodes)
         public MdlStructs.MeshStruct          MeshStruct;
         public List<MdlStructs.SubmeshStruct> SubMeshStructs;
 
+        public string? Material;
+
         public MdlStructs.VertexDeclarationStruct VertexDeclaration;
         public IEnumerable<byte>                  VertexBuffer;
 
@@ -34,6 +36,8 @@ public class MeshImporter(IEnumerable<Node> nodes)
     }
 
     private readonly List<MdlStructs.SubmeshStruct> _subMeshes = [];
+
+    private string? _material;
 
     private          MdlStructs.VertexDeclarationStruct? _vertexDeclaration;
     private          byte[]?                             _strides;
@@ -74,6 +78,7 @@ public class MeshImporter(IEnumerable<Node> nodes)
                 BoneTableIndex = 0,
             },
             SubMeshStructs    = _subMeshes,
+            Material          = _material,
             VertexDeclaration = _vertexDeclaration.Value,
             VertexBuffer      = _streams[0].Concat(_streams[1]).Concat(_streams[2]),
             Indices           = _indices,
@@ -104,6 +109,9 @@ public class MeshImporter(IEnumerable<Node> nodes)
         var subMesh     = SubMeshImporter.Import(node, nodeBoneMap);
 
         var subMeshName = node.Name ?? node.Mesh.Name;
+
+        // TODO: Record a warning if there's a mismatch between current and incoming, as we can't support multiple materials per mesh.
+        _material ??= subMesh.Material;
 
         // Check that vertex declarations match - we need to combine the buffers, so a mismatch would take a whole load of resolution.
         if (_vertexDeclaration == null)

--- a/Penumbra/Import/Models/Import/MeshImporter.cs
+++ b/Penumbra/Import/Models/Import/MeshImporter.cs
@@ -19,6 +19,8 @@ public class MeshImporter(IEnumerable<Node> nodes)
 
         public List<string>? Bones;
 
+        public List<string> MetaAttributes;
+
         public List<MeshShapeKey> ShapeKeys;
     }
 
@@ -47,6 +49,8 @@ public class MeshImporter(IEnumerable<Node> nodes)
     private readonly List<ushort> _indices = [];
 
     private List<string>? _bones;
+
+    private readonly List<string> _metaAttributes = [];
 
     private readonly Dictionary<string, List<MdlStructs.ShapeValueStruct>> _shapeValues = [];
 
@@ -83,6 +87,7 @@ public class MeshImporter(IEnumerable<Node> nodes)
             VertexBuffer      = _streams[0].Concat(_streams[1]).Concat(_streams[2]),
             Indices           = _indices,
             Bones             = _bones,
+            MetaAttributes    = _metaAttributes,
             ShapeKeys = _shapeValues
                 .Select(pair => new MeshShapeKey()
                 {
@@ -153,6 +158,8 @@ public class MeshImporter(IEnumerable<Node> nodes)
         _subMeshes.Add(subMesh.SubMeshStruct with
         {
             IndexOffset = (ushort)(subMesh.SubMeshStruct.IndexOffset + indexOffset),
+            AttributeIndexMask = Utility.GetMergedAttributeMask(
+                subMesh.SubMeshStruct.AttributeIndexMask, subMesh.MetaAttributes, _metaAttributes),
         });
     }
 

--- a/Penumbra/Import/Models/Import/ModelImporter.cs
+++ b/Penumbra/Import/Models/Import/ModelImporter.cs
@@ -136,14 +136,14 @@ public partial class ModelImporter(ModelRoot model)
         var mesh           = MeshImporter.Import(subMeshNodes);
         var meshStartIndex = (uint)(mesh.MeshStruct.StartIndex + indexOffset);
 
-        ushort materialIndex = 0;
-        if (mesh.Material != null)
-            materialIndex = GetMaterialIndex(mesh.Material);
+        var materialIndex = mesh.Material != null
+            ? GetMaterialIndex(mesh.Material)
+            : (ushort)0;
 
         // If no bone table is used for a mesh, the index is set to 255.
-        ushort boneTableIndex = 255;
-        if (mesh.Bones != null)
-            boneTableIndex = BuildBoneTable(mesh.Bones);
+        var boneTableIndex = mesh.Bones != null
+            ? BuildBoneTable(mesh.Bones)
+            : (ushort)255;
 
         _meshes.Add(mesh.MeshStruct with
         {
@@ -196,7 +196,7 @@ public partial class ModelImporter(ModelRoot model)
 
     private ushort GetMaterialIndex(string materialName)
     {
-        // If we already have this material, grab the current one
+        // If we already have this material, grab the current index.
         var index = _materials.IndexOf(materialName);
         if (index >= 0)
             return (ushort)index;

--- a/Penumbra/Import/Models/Import/ModelImporter.cs
+++ b/Penumbra/Import/Models/Import/ModelImporter.cs
@@ -29,6 +29,8 @@ public partial class ModelImporter(ModelRoot _model)
     private readonly List<string>                     _bones      = [];
     private readonly List<MdlStructs.BoneTableStruct> _boneTables = [];
 
+    private readonly List<string> _metaAttributes = [];
+
     private readonly Dictionary<string, List<MdlStructs.ShapeMeshStruct>> _shapeMeshes = [];
     private readonly List<MdlStructs.ShapeValueStruct>                    _shapeValues = [];
 
@@ -71,6 +73,7 @@ public partial class ModelImporter(ModelRoot _model)
             Bones              = [.. _bones],
             // TODO: Game doesn't seem to rely on this, but would be good to populate.
             SubMeshBoneMap = [],
+            Attributes     = [.. _metaAttributes],
             Shapes         = [.. shapes],
             ShapeMeshes    = [.. shapeMeshes],
             ShapeValues    = [.. _shapeValues],
@@ -155,6 +158,8 @@ public partial class ModelImporter(ModelRoot _model)
 
         _subMeshes.AddRange(mesh.SubMeshStructs.Select(m => m with
         {
+            AttributeIndexMask = Utility.GetMergedAttributeMask(
+                m.AttributeIndexMask, mesh.MetaAttributes, _metaAttributes),
             IndexOffset = (uint)(m.IndexOffset + indexOffset),
         }));
 

--- a/Penumbra/Import/Models/Import/SubMeshImporter.cs
+++ b/Penumbra/Import/Models/Import/SubMeshImporter.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Lumina.Data.Parsing;
 using OtterGui;
 using SharpGLTF.Schema2;
@@ -20,6 +21,8 @@ public class SubMeshImporter
 
         public ushort[] Indices;
 
+        public string[] MetaAttributes;
+
         public Dictionary<string, List<MdlStructs.ShapeValueStruct>> ShapeValues;
     }
 
@@ -29,16 +32,19 @@ public class SubMeshImporter
         return importer.Create();
     }
 
-    private readonly MeshPrimitive                _primitive;
-    private readonly IDictionary<ushort, ushort>? _nodeBoneMap;
+    private readonly MeshPrimitive                     _primitive;
+    private readonly IDictionary<ushort, ushort>?      _nodeBoneMap;
+    private readonly IDictionary<string, JsonElement>? _nodeExtras;
 
-    private List<VertexAttribute>? _attributes;
+    private List<VertexAttribute>? _vertexAttributes;
 
     private          ushort       _vertexCount;
     private          byte[]       _strides = [0, 0, 0];
     private readonly List<byte>[] _streams;
 
     private ushort[]? _indices;
+
+    private string[]? _metaAttributes;
 
     private readonly List<string>?                                          _morphNames;
     private          Dictionary<string, List<MdlStructs.ShapeValueStruct>>? _shapeValues;
@@ -59,6 +65,15 @@ public class SubMeshImporter
 
         try
         {
+            _nodeExtras = node.Extras.Deserialize<Dictionary<string, JsonElement>>();
+        }
+        catch
+        {
+            _nodeExtras = null;    
+        }
+
+        try
+        {
             _morphNames = mesh.Extras.GetNode("targetNames").Deserialize<List<string>>();
         }
         catch
@@ -76,16 +91,26 @@ public class SubMeshImporter
     {
         // Build all the data we'll need.
         BuildIndices();
-        BuildAttributes();
+        BuildVertexAttributes();
         BuildVertices();
+        BuildMetaAttributes();
 
         ArgumentNullException.ThrowIfNull(_indices);
-        ArgumentNullException.ThrowIfNull(_attributes);
+        ArgumentNullException.ThrowIfNull(_vertexAttributes);
         ArgumentNullException.ThrowIfNull(_shapeValues);
+        ArgumentNullException.ThrowIfNull(_metaAttributes);
 
         var material = _primitive.Material.Name;
         if (material == "")
             material = null;
+
+        // At this level, we assume that attributes are wholly controlled by this sub-mesh.
+        var attributeMask = _metaAttributes.Length switch
+        {
+            < 32 => (1u << _metaAttributes.Length) - 1,
+              32 => uint.MaxValue,
+            > 32 => throw new Exception("Models may utilise a maximum of 32 attributes."),
+        };
 
         return new SubMesh()
         {
@@ -93,7 +118,7 @@ public class SubMeshImporter
             {
                 IndexOffset        = 0,
                 IndexCount         = (uint)_indices.Length,
-                AttributeIndexMask = 0,
+                AttributeIndexMask = attributeMask,
 
                 // TODO: Flesh these out. Game doesn't seem to rely on them existing, though.
                 BoneStartIndex = 0,
@@ -102,12 +127,13 @@ public class SubMeshImporter
             Material = material,
             VertexDeclaration = new MdlStructs.VertexDeclarationStruct()
             {
-                VertexElements = _attributes.Select(attribute => attribute.Element).ToArray(),
+                VertexElements = _vertexAttributes.Select(attribute => attribute.Element).ToArray(),
             },
             VertexCount = _vertexCount,
             Strides     = _strides,
             Streams     = _streams,
             Indices     = _indices,
+            MetaAttributes  = _metaAttributes, 
             ShapeValues = _shapeValues,
         };
     }
@@ -117,7 +143,7 @@ public class SubMeshImporter
         _indices = _primitive.GetIndices().Select(idx => (ushort)idx).ToArray();
     }
 
-    private void BuildAttributes()
+    private void BuildVertexAttributes()
     {
         var accessors = _primitive.VertexAccessors;
 
@@ -153,14 +179,14 @@ public class SubMeshImporter
             offsets[attribute.Stream] += attribute.Size;
         }
 
-        _attributes = attributes;
+        _vertexAttributes = attributes;
         // After building the attributes, the resulting next offsets are our stream strides.
         _strides = offsets;
     }
 
     private void BuildVertices()
     {
-        ArgumentNullException.ThrowIfNull(_attributes);
+        ArgumentNullException.ThrowIfNull(_vertexAttributes);
 
         // Lists of vertex indices that are effected by each morph target for this primitive.
         var morphModifiedVertices = Enumerable.Range(0, _primitive.MorphTargetsCount)
@@ -173,13 +199,13 @@ public class SubMeshImporter
         for (var vertexIndex = 0; vertexIndex < _vertexCount; vertexIndex++)
         {
             // Write out vertex data to streams for each attribute.
-            foreach (var attribute in _attributes)
+            foreach (var attribute in _vertexAttributes)
                 _streams[attribute.Stream].AddRange(attribute.Build(vertexIndex));
 
             // Record which morph targets have values for this vertex, if any.
             var changedMorphs = morphModifiedVertices
                 .WithIndex()
-                .Where(pair => _attributes.Any(attribute => attribute.HasMorph(pair.Index, vertexIndex)))
+                .Where(pair => _vertexAttributes.Any(attribute => attribute.HasMorph(pair.Index, vertexIndex)))
                 .Select(pair => pair.Value);
             foreach (var modifiedVertices in changedMorphs)
                 modifiedVertices.Add(vertexIndex);
@@ -191,7 +217,7 @@ public class SubMeshImporter
     private void BuildShapeValues(IEnumerable<List<int>> morphModifiedVertices)
     {
         ArgumentNullException.ThrowIfNull(_indices);
-        ArgumentNullException.ThrowIfNull(_attributes);
+        ArgumentNullException.ThrowIfNull(_vertexAttributes);
 
         var morphShapeValues = new Dictionary<string, List<MdlStructs.ShapeValueStruct>>();
 
@@ -203,7 +229,7 @@ public class SubMeshImporter
             foreach (var vertexIndex in modifiedVertices)
             {
                 // Write out the morphed vertex to the vertex streams.
-                foreach (var attribute in _attributes)
+                foreach (var attribute in _vertexAttributes)
                     _streams[attribute.Stream].AddRange(attribute.BuildMorph(morphIndex, vertexIndex));
 
                 // Find any indices that target this vertex index and create a mapping.
@@ -223,5 +249,14 @@ public class SubMeshImporter
         }
 
         _shapeValues = morphShapeValues;
+    }
+
+    private void BuildMetaAttributes()
+    {
+        // We consider any "extras" key with a boolean value set to `true` to be an attribute.
+        _metaAttributes = _nodeExtras?
+            .Where(pair => pair.Value.ValueKind == JsonValueKind.True)
+            .Select(pair => pair.Key)
+            .ToArray() ?? [];
     }
 }

--- a/Penumbra/Import/Models/Import/SubMeshImporter.cs
+++ b/Penumbra/Import/Models/Import/SubMeshImporter.cs
@@ -10,6 +10,8 @@ public class SubMeshImporter
     {
         public MdlStructs.SubmeshStruct SubMeshStruct;
 
+        public string? Material;
+
         public MdlStructs.VertexDeclarationStruct VertexDeclaration;
 
         public ushort       VertexCount;
@@ -81,6 +83,10 @@ public class SubMeshImporter
         ArgumentNullException.ThrowIfNull(_attributes);
         ArgumentNullException.ThrowIfNull(_shapeValues);
 
+        var material = _primitive.Material.Name;
+        if (material == "")
+            material = null;
+
         return new SubMesh()
         {
             SubMeshStruct = new MdlStructs.SubmeshStruct()
@@ -93,6 +99,7 @@ public class SubMeshImporter
                 BoneStartIndex = 0,
                 BoneCount      = 0,
             },
+            Material = material,
             VertexDeclaration = new MdlStructs.VertexDeclarationStruct()
             {
                 VertexElements = _attributes.Select(attribute => attribute.Element).ToArray(),

--- a/Penumbra/Import/Models/Import/SubMeshImporter.cs
+++ b/Penumbra/Import/Models/Import/SubMeshImporter.cs
@@ -69,7 +69,7 @@ public class SubMeshImporter
         }
         catch
         {
-            _nodeExtras = null;    
+            _nodeExtras = null;
         }
 
         try

--- a/Penumbra/Import/Models/Import/Utility.cs
+++ b/Penumbra/Import/Models/Import/Utility.cs
@@ -1,0 +1,34 @@
+namespace Penumbra.Import.Models.Import;
+
+public static class Utility
+{
+    /// <summary> Merge attributes into an existing attribute array, providing an updated submesh mask. </summary>
+    /// <param name="oldMask"> Old submesh attribute mask. </param>
+    /// <param name="oldAttributes"> Old attribute array that should be merged. </param>
+    /// <param name="newAttributes"> New attribute array. Will be mutated. </param>
+    /// <returns> New submesh attribute mask, updated to match the merged attribute array. </returns>
+    public static uint GetMergedAttributeMask(uint oldMask, IList<string> oldAttributes, List<string> newAttributes)
+    {
+        var metaAttributes = Enumerable.Range(0, 32)
+            .Where(index => ((oldMask >> index) & 1) == 1)
+            .Select(index => oldAttributes[index]);
+
+        var newMask = 0u;
+
+        foreach (var metaAttribute in metaAttributes)
+        {
+            var attributeIndex = newAttributes.IndexOf(metaAttribute);
+            if (attributeIndex == -1)
+            {
+                if (newAttributes.Count >= 32)
+                    throw new Exception("Models may utilise a maximum of 32 attributes.");
+
+                newAttributes.Add(metaAttribute);
+                attributeIndex = newAttributes.Count - 1;
+            }
+            newMask |= 1u << attributeIndex;
+        }
+
+        return newMask;
+    }
+}

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -80,6 +80,7 @@ public partial class ModEditWindow
         using (var frame = ImRaii.FramedGroup("Import", size, headerPreIcon: FontAwesomeIcon.FileImport))
         {
             ImGui.Checkbox("Keep current materials", ref tab.ImportKeepMaterials);
+            ImGui.Checkbox("Keep current attributes", ref tab.ImportKeepAttributes);
 
             if (ImGuiUtil.DrawDisabledButton("Import from glTF", Vector2.Zero, "Imports a glTF file, overriding the content of this mdl.",
                     tab.PendingIo))

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -479,5 +479,6 @@ public partial class ModEditWindow
     private static readonly string[] ValidModelExtensions =
     [
         ".gltf",
+        ".glb",
     ];
 }

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -79,6 +79,8 @@ public partial class ModEditWindow
 
         using (var frame = ImRaii.FramedGroup("Import", size, headerPreIcon: FontAwesomeIcon.FileImport))
         {
+            ImGui.Checkbox("Keep current materials", ref tab.ImportKeepMaterials);
+
             if (ImGuiUtil.DrawDisabledButton("Import from glTF", Vector2.Zero, "Imports a glTF file, overriding the content of this mdl.",
                     tab.PendingIo))
                 _fileDialog.OpenFilePicker("Load model from glTF.", "glTF{.gltf,.glb}", (success, paths) =>
@@ -86,7 +88,6 @@ public partial class ModEditWindow
                     if (success && paths.Count > 0)
                         tab.Import(paths[0]);
                 }, 1, _mod!.ModPath.FullName, false);
-            ImGui.Dummy(new Vector2(ImGui.GetFrameHeight()));
         }
 
         if (_dragDropManager.CreateImGuiTarget("ModelDragDrop", out var files, out _) && GetFirstModel(files, out var importFile))


### PR DESCRIPTION
Title. As specified, this is just the _names_ - it isn't material composition (yet).

Material names are imported and exported using the names of the material nodes in the gltf format. No processing is done on these - they're kept exactly as the strings used by the game. This is primarily due to the mixed usage of material names in-game - for now, I'd like to keep the strings as a "black box" so to speak, to avoid dealing with all the different model type's material name semantics.

Attributes are imported and exported exported as "extras" - space reserved by the specification for arbitrary additional data. In particular, this is pretty handy for blender, as blender will import (and can be configured to export) these from it's "custom properties", which gives us a nice UX point for editing these values in 3d workspace tools.

- I'm choosing not to assign any semantics to the names of attributes, as (as discussed), there are already plugins that use non-`atr_` prefixes for logic
- I'm choosing not to use a less-arbitrary storage (i.e. morph target names) for attribute storage to avoid overloading concepts and/or getting into semantics muddy water.