### PR TITLE
.mdl io: Export composed materials

### DIFF
--- a/Penumbra/Import/Models/Export/MaterialExporter.cs
+++ b/Penumbra/Import/Models/Export/MaterialExporter.cs
@@ -26,8 +26,10 @@ public class MaterialExporter
         Penumbra.Log.Debug($"Exporting material \"{name}\".");
         return material.Mtrl.ShaderPackage.Name switch
         {
-            "character.shpk" => BuildCharacter(material, name),
-            _                => BuildFallback(material, name),
+            // NOTE: this isn't particularly precise to game behavior (it has some fade around high opacity), but good enough for now.
+            "character.shpk"      => BuildCharacter(material, name).WithAlpha(AlphaMode.MASK, 0.5f),
+            "characterglass.shpk" => BuildCharacter(material, name).WithAlpha(AlphaMode.BLEND),
+            _                     => BuildFallback(material, name),
         };
     }
 
@@ -59,8 +61,6 @@ public class MaterialExporter
         var imageName = name.Replace("/", "").Replace(".mtrl", "");
 
         return BuildSharedBase(material, name)
-            // NOTE: this isn't particularly precise to game behavior, but good enough for now.
-            .WithAlpha(AlphaMode.MASK, 0.5f)
             .WithBaseColor(BuildImage(baseColor, $"{imageName}_basecolor"))
             .WithNormal(BuildImage(operation.Normal, $"{imageName}_normal"))
             .WithSpecularColor(BuildImage(specular, $"{imageName}_specular"))

--- a/Penumbra/Import/Models/Export/MaterialExporter.cs
+++ b/Penumbra/Import/Models/Export/MaterialExporter.cs
@@ -13,22 +13,16 @@ using ImageSharpConfiguration = SixLabors.ImageSharp.Configuration;
 
 public class MaterialExporter
 {
-    // input stuff
     public struct Material
     {
         public MtrlFile Mtrl;
-        public Sampler[] Samplers;
+        public Dictionary<TextureUsage, Image<Rgba32>> Textures;
         // variant?
-    }
-
-    public struct Sampler
-    {
-        public TextureUsage Usage;
-        public Image<Rgba32> Texture;
     }
 
     public static MaterialBuilder Export(Material material, string name)
     {
+        Penumbra.Log.Debug($"Exporting material \"{name}\".");
         return material.Mtrl.ShaderPackage.Name switch
         {
             "character.shpk" => BuildCharacter(material, name),
@@ -40,11 +34,10 @@ public class MaterialExporter
     {
         // TODO: handle models with an underlying diffuse
         var table = material.Mtrl.Table;
-        // TODO: this should probably be a dict
-        var normal = material.Samplers
-            .Where(s => s.Usage == TextureUsage.SamplerNormal)
-            .First()
-            .Texture;
+
+        // TODO: there's a few normal usages i should check, i think.
+        // TODO: tryget
+        var normal = material.Textures[TextureUsage.SamplerNormal];
 
         var operation = new ProcessCharacterNormalOperation(normal, table);
         ParallelRowIterator.IterateRows(ImageSharpConfiguration.Default, normal.Bounds(), in operation);

--- a/Penumbra/Import/Models/Export/MaterialExporter.cs
+++ b/Penumbra/Import/Models/Export/MaterialExporter.cs
@@ -1,0 +1,81 @@
+using Lumina.Data.Parsing;
+using Penumbra.GameData.Files;
+using SharpGLTF.Materials;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Penumbra.Import.Models.Export;
+
+public class MaterialExporter
+{
+    // input stuff
+    public struct Material
+    {
+        public MtrlFile Mtrl;
+        public Sampler[] Samplers;
+        // variant?
+    }
+
+    public struct Sampler
+    {
+        public TextureUsage Usage;
+        public Image<Rgba32> Texture;
+    }
+
+    public static MaterialBuilder Export(Material material, string name)
+    {
+        return material.Mtrl.ShaderPackage.Name switch
+        {
+            "character.shpk" => BuildCharacter(material, name),
+            _                => BuildFallback(material, name),
+        };
+    }
+
+    private static MaterialBuilder BuildCharacter(Material material, string name)
+    {
+        // TODO: pixelbashing time
+        var sampler = material.Samplers
+            .Where(s => s.Usage == TextureUsage.SamplerNormal)
+            .First();
+
+        // TODO: clean up this name generation a bunch. probably a method.
+        var imageName = name.Replace("/", "");
+        var baseColor = BuildImage(sampler.Texture, $"{imageName}_basecolor");
+
+        return BuildSharedBase(material, name)
+            .WithBaseColor(baseColor);
+    }
+
+    private static MaterialBuilder BuildFallback(Material material, string name)
+    {
+        Penumbra.Log.Warning($"Unhandled shader package: {material.Mtrl.ShaderPackage.Name}");
+        return BuildSharedBase(material, name)
+            .WithMetallicRoughnessShader()
+            .WithChannelParam(KnownChannel.BaseColor, KnownProperty.RGBA, Vector4.One);
+    }
+
+    private static MaterialBuilder BuildSharedBase(Material material, string name)
+    {
+        // TODO: Move this and potentially the other known stuff into MtrlFile?
+        const uint backfaceMask = 0x1;
+        var showBackfaces = (material.Mtrl.ShaderPackage.Flags & backfaceMask) == 0;
+
+        return new MaterialBuilder(name)
+            .WithDoubleSide(showBackfaces);
+    }
+
+    private static ImageBuilder BuildImage(Image<Rgba32> image, string name)
+    {
+        byte[] textureBytes;
+        using (var memoryStream = new MemoryStream())
+        {
+            image.Save(memoryStream, PngFormat.Instance);
+            textureBytes = memoryStream.ToArray();
+        }
+
+        var imageBuilder = ImageBuilder.From(textureBytes, name);
+        imageBuilder.AlternateWriteFileName = $"{name}.*";
+        return imageBuilder;
+    }
+}

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
@@ -225,15 +225,16 @@ public partial class ModEditWindow
         private byte[] ReadFile(string path)
         {
             // TODO: if cross-collection lookups are turned off, this conversion can be skipped
-            if (!Utf8GamePath.FromString(path, out var utf8SklbPath, true))
+            if (!Utf8GamePath.FromString(path, out var utf8Path, true))
                 throw new Exception($"Resolved path {path} could not be converted to a game path.");
 
-            var resolvedPath = _edit._activeCollections.Current.ResolvePath(utf8SklbPath);
+            var resolvedPath = _edit._activeCollections.Current.ResolvePath(utf8Path);
             // TODO: is it worth trying to use streams for these instead? I'll need to do this for mtrl/tex too, so might be a good idea. that said, the mtrl reader doesn't accept streams, so...
             var bytes = resolvedPath == null 
                 ? _edit._gameData.GetFile(path)?.Data
                 : File.ReadAllBytes(resolvedPath.Value.ToPath());
 
+            // TODO: some callers may not care about failures - handle exceptions seperately?
             return bytes ?? throw new Exception(
                 $"Resolved path {path} could not be found. If modded, is it enabled in the current collection?");
         }

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -138,14 +138,14 @@ public partial class ModEditWindow
         using var frame = ImRaii.FramedGroup("Exceptions", size, headerPreIcon: FontAwesomeIcon.TimesCircle, borderColor: Colors.RegexWarningBorder);
 
         var spaceAvail = ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X - 100;
-        foreach (var exception in tab.IoExceptions)
+        foreach (var (exception, index) in tab.IoExceptions.WithIndex())
         {
             var message = $"{exception.GetType().Name}: {exception.Message}";
             var textSize = ImGui.CalcTextSize(message).X;
             if (textSize > spaceAvail)
                 message = message.Substring(0, (int)Math.Floor(message.Length * (spaceAvail / textSize))) + "...";
 
-            using (var exceptionNode = ImRaii.TreeNode(message))
+            using (var exceptionNode = ImRaii.TreeNode($"{message}###exception{index}"))
             {
                 if (exceptionNode)
                     ImGuiUtil.TextWrapped(exception.ToString());


### PR DESCRIPTION
Big one sorry. Hopefully the last major full-feature that needs to be added - most things from here out should be more iterative. I hope. Maybe. Refactors not included. Not including shapekey transforms too that's gonna be a big one. Ramble.

This PR fleshes out the previously placeholder white texture generation with material & texture composition that _loosely_ mimics the game. Keyword "loose" - it's fairly similar to TexTool's behavior, for now. The exported textures are designed to be aids when working with the models in 3d apps, and that's about it.

yada yada