### PR TITLE
.mdl io: Triage pass 1

### DIFF
--- a/Penumbra/Import/Models/Import/BoundingBox.cs
+++ b/Penumbra/Import/Models/Import/BoundingBox.cs
@@ -1,0 +1,33 @@
+using Lumina.Data.Parsing;
+
+namespace Penumbra.Import.Models.Import;
+
+/// <summary> Mutable representation of the bounding box surrouding a collection of vertices. </summary>
+public class BoundingBox
+{
+    private Vector3 _minimum = Vector3.Zero;
+    private Vector3 _maximum = Vector3.Zero;
+
+    /// <summary> Use the specified position to update this bounding box, expanding it if necessary. </summary>
+    public void Merge(Vector3 position)
+    {
+        _minimum = Vector3.Min(_minimum, position);
+        _maximum = Vector3.Max(_maximum, position);
+    }
+
+    /// <summary> Merge the provided bounding box into this one, expanding it if necessary. </summary>
+    /// <param name="other"></param>
+    public void Merge(BoundingBox other)
+    {
+        _minimum = Vector3.Min(_minimum, other._minimum);
+        _maximum = Vector3.Max(_maximum, other._maximum);
+    }
+
+    /// <summary> Convert this bounding box to the struct format used in .mdl data structures. </summary>
+    public MdlStructs.BoundingBoxStruct ToStruct()
+        => new MdlStructs.BoundingBoxStruct
+        {
+            Min = [_minimum.X, _minimum.Y, _minimum.Z, 1],
+            Max = [_maximum.X, _maximum.Y, _maximum.Z, 1],
+        };
+}

--- a/Penumbra/Import/Models/Import/MeshImporter.cs
+++ b/Penumbra/Import/Models/Import/MeshImporter.cs
@@ -19,6 +19,8 @@ public class MeshImporter(IEnumerable<Node> nodes)
 
         public List<string>? Bones;
 
+        public BoundingBox BoundingBox;
+
         public List<string> MetaAttributes;
 
         public List<MeshShapeKey> ShapeKeys;
@@ -49,6 +51,8 @@ public class MeshImporter(IEnumerable<Node> nodes)
     private readonly List<ushort> _indices = [];
 
     private List<string>? _bones;
+
+    private readonly BoundingBox _boundingBox = new BoundingBox();
 
     private readonly List<string> _metaAttributes = [];
 
@@ -87,6 +91,7 @@ public class MeshImporter(IEnumerable<Node> nodes)
             VertexBuffer      = _streams[0].Concat(_streams[1]).Concat(_streams[2]),
             Indices           = _indices,
             Bones             = _bones,
+            BoundingBox       = _boundingBox,
             MetaAttributes    = _metaAttributes,
             ShapeKeys = _shapeValues
                 .Select(pair => new MeshShapeKey()
@@ -153,6 +158,8 @@ public class MeshImporter(IEnumerable<Node> nodes)
                 ReplacingVertexIndex = (ushort)(value.ReplacingVertexIndex + vertexOffset),
             }));
         }
+
+        _boundingBox.Merge(subMesh.BoundingBox);
 
         // And finally, merge in the sub-mesh struct itself.
         _subMeshes.Add(subMesh.SubMeshStruct with

--- a/Penumbra/Import/Models/Import/ModelImporter.cs
+++ b/Penumbra/Import/Models/Import/ModelImporter.cs
@@ -29,6 +29,8 @@ public partial class ModelImporter(ModelRoot model)
     private readonly List<string>                     _bones      = [];
     private readonly List<MdlStructs.BoneTableStruct> _boneTables = [];
 
+    private readonly BoundingBox _boundingBox = new BoundingBox();
+
     private readonly List<string> _metaAttributes = [];
 
     private readonly Dictionary<string, List<MdlStructs.ShapeMeshStruct>> _shapeMeshes = [];
@@ -95,9 +97,10 @@ public partial class ModelImporter(ModelRoot model)
 
             Materials = [.. materials],
 
+            BoundingBoxes = _boundingBox.ToStruct(),
+
             // TODO: Would be good to calculate all of this up the tree.
             Radius            = 1,
-            BoundingBoxes     = MdlFile.EmptyBoundingBox,
             BoneBoundingBoxes = Enumerable.Repeat(MdlFile.EmptyBoundingBox, _bones.Count).ToArray(),
             RemainingData     = [.._vertexBuffer, ..indexBuffer],
         };
@@ -155,6 +158,8 @@ public partial class ModelImporter(ModelRoot model)
                 .Select(offset => (uint)(offset + vertexOffset))
                 .ToArray(),
         });
+
+        _boundingBox.Merge(mesh.BoundingBox);
 
         _subMeshes.AddRange(mesh.SubMeshStructs.Select(m => m with
         {

--- a/Penumbra/Import/Models/Import/SubMeshImporter.cs
+++ b/Penumbra/Import/Models/Import/SubMeshImporter.cs
@@ -21,6 +21,8 @@ public class SubMeshImporter
 
         public ushort[] Indices;
 
+        public BoundingBox BoundingBox;
+
         public string[] MetaAttributes;
 
         public Dictionary<string, List<MdlStructs.ShapeValueStruct>> ShapeValues;
@@ -43,6 +45,8 @@ public class SubMeshImporter
     private readonly List<byte>[] _streams;
 
     private ushort[]? _indices;
+
+    private BoundingBox _boundingBox = new BoundingBox();
 
     private string[]? _metaAttributes;
 
@@ -90,9 +94,11 @@ public class SubMeshImporter
     private SubMesh Create()
     {
         // Build all the data we'll need.
+        // TODO: This structure is verging on a little silly. Reconsider.
         BuildIndices();
         BuildVertexAttributes();
         BuildVertices();
+        BuildBoundingBox();
         BuildMetaAttributes();
 
         ArgumentNullException.ThrowIfNull(_indices);
@@ -133,6 +139,7 @@ public class SubMeshImporter
             Strides     = _strides,
             Streams     = _streams,
             Indices     = _indices,
+            BoundingBox = _boundingBox,
             MetaAttributes  = _metaAttributes, 
             ShapeValues = _shapeValues,
         };
@@ -253,6 +260,13 @@ public class SubMeshImporter
         }
 
         _shapeValues = morphShapeValues;
+    }
+
+    private void BuildBoundingBox()
+    {
+        var positions = _primitive.VertexAccessors["POSITION"].AsVector3Array();
+        foreach (var position in positions)
+            _boundingBox.Merge(position);
     }
 
     private void BuildMetaAttributes()

--- a/Penumbra/Import/Models/Import/VertexAttribute.cs
+++ b/Penumbra/Import/Models/Import/VertexAttribute.cs
@@ -394,10 +394,9 @@ public class VertexAttribute
         return result;
     }
 
-    public static VertexAttribute? Color(Accessors accessors)
+    public static VertexAttribute Color(Accessors accessors)
     {
-        if (!accessors.TryGetValue("COLOR_0", out var accessor))
-            return null;
+        accessors.TryGetValue("COLOR_0", out var accessor);
 
         var element = new MdlStructs.VertexElement()
         {
@@ -406,11 +405,12 @@ public class VertexAttribute
             Usage  = (byte)MdlFile.VertexUsage.Color,
         };
 
-        var values = accessor.AsVector4Array();
+        // Some shaders rely on the presence of vertex colors to render - fall back to a pure white value if it's missing.
+        var values = accessor?.AsVector4Array();
 
         return new VertexAttribute(
             element,
-            index => BuildByteFloat4(values[index])
+            index => BuildByteFloat4(values?[index] ?? Vector4.One)
         );
     }
 

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
@@ -259,11 +259,12 @@ public partial class ModEditWindow
             if (!Utf8GamePath.FromString(path, out var utf8Path, true))
                 throw new Exception($"Resolved path {path} could not be converted to a game path.");
 
-            var resolvedPath = _edit._activeCollections.Current.ResolvePath(utf8Path);
+            var resolvedPath = _edit._activeCollections.Current.ResolvePath(utf8Path) ?? new FullPath(utf8Path);
+
             // TODO: is it worth trying to use streams for these instead? I'll need to do this for mtrl/tex too, so might be a good idea. that said, the mtrl reader doesn't accept streams, so...
-            var bytes = resolvedPath == null 
-                ? _edit._gameData.GetFile(path)?.Data
-                : File.ReadAllBytes(resolvedPath.Value.ToPath());
+            var bytes = resolvedPath.IsRooted
+                ? File.ReadAllBytes(resolvedPath.FullName)
+                : _edit._gameData.GetFile(resolvedPath.InternalName.ToString())?.Data;
 
             // TODO: some callers may not care about failures - handle exceptions separately?
             return bytes ?? throw new Exception(

--- a/Penumbra/UI/Changelog.cs
+++ b/Penumbra/UI/Changelog.cs
@@ -54,7 +54,7 @@ public class PenumbraChangelog
     private static void Add1_0_0_0(Changelog log)
         => log.NextVersion("Version 1.0.0.0")
             .RegisterHighlight("Mods in the mod selector can now be filtered by changed item categories.")
-            .RegisterHighlight("Model Editing options in the Advanced Editing Window have been greatly extended (by Ackwell):")
+            .RegisterHighlight("Model Editing options in the Advanced Editing Window have been greatly extended (by ackwell):")
             .RegisterEntry("Attributes and referenced materials can now be set per mesh.", 1)
             .RegisterEntry("Model files (.mdl) can now be exported to the well-established glTF format, which can be imported e.g. by Blender.", 1)
             .RegisterEntry("glTF files can also be imported back to a .mdl file.", 1)


### PR DESCRIPTION
This is a collection of smaller fixes, collated from reports over the day. Each commit should be a self-contained fix and independently reviewable.

- 499aae09c093831914953331a8b6a18bef74255e: Due to not calculating bounding boxes, some models such as weapons would "flicker" - this was caused by the all-0 bounding boxes causing the model to be considered "behind" things at any point the model's origin was. Fix is to calculate bounding box correctly. Notably this does not calculate bone bounds, only the main model one. Bones would be a lot more complicated, but will be revisited later.
- e2369b590ef82819919c5a9e071b725fc194a52e: Not actually a fix for anything, but I wrote this trying to fix the bounding box issue before that's what i realised it was, so including it anyway. This should make weapons more accurate when importing.
- f4d918095633b33c161cbb2c51f02bc87a8520ea: Importing without a colour attribute can result in meshes not rendering at all sometimes, or otherwise just looking _very_ wrong. This just makes colour fall back to pure white if no attribute is defined in the gltf. May also reduce vertex decl mismatch frequency, too.
- f24c11d752ea4e67404912a9482957e45826a241: I derped the file path resolution for reading game vs fs data, resulting in file swaps breaking exports. This updates it to use the same basic control flow as item swap.