### PR TITLE
.mdl io: Fallible actions.

### DIFF
--- a/Penumbra/Import/Models/Export/Config.cs
+++ b/Penumbra/Import/Models/Export/Config.cs
@@ -1,0 +1,6 @@
+namespace Penumbra.Import.Models.Export;
+
+public struct ExportConfig
+{
+    public bool GenerateMissingBones;
+}

--- a/Penumbra/Import/Models/Export/MaterialExporter.cs
+++ b/Penumbra/Import/Models/Export/MaterialExporter.cs
@@ -23,7 +23,7 @@ public class MaterialExporter
     }
 
     /// <summary> Build a glTF material from a hydrated XIV model, with the provided name. </summary>
-    public static MaterialBuilder Export(Material material, string name)
+    public static MaterialBuilder Export(Material material, string name, IoNotifier notifier)
     {
         Penumbra.Log.Debug($"Exporting material \"{name}\".");
         return material.Mtrl.ShaderPackage.Name switch
@@ -34,7 +34,7 @@ public class MaterialExporter
             "hair.shpk"           => BuildHair(material, name),
             "iris.shpk"           => BuildIris(material, name),
             "skin.shpk"           => BuildSkin(material, name),
-            _                     => BuildFallback(material, name),
+            _                     => BuildFallback(material, name, notifier),
         };
     }
 
@@ -335,9 +335,9 @@ public class MaterialExporter
 
     /// <summary> Build a material from a source with unknown semantics. </summary>
     /// <remarks> Will make a loose effort to fetch common / simple textures. </remarks>
-    private static MaterialBuilder BuildFallback(Material material, string name)
+    private static MaterialBuilder BuildFallback(Material material, string name, IoNotifier notifier)
     {
-        Penumbra.Log.Warning($"Unhandled shader package: {material.Mtrl.ShaderPackage.Name}");
+        notifier.Warning($"Unhandled shader package: {material.Mtrl.ShaderPackage.Name}");
 
         var materialBuilder = BuildSharedBase(material, name)
             .WithMetallicRoughnessShader()

--- a/Penumbra/Import/Models/Export/MaterialExporter.cs
+++ b/Penumbra/Import/Models/Export/MaterialExporter.cs
@@ -22,6 +22,12 @@ public class MaterialExporter
         // variant?
     }
 
+    /// <summary> Dependency-less material configuration, for use when no material data can be resolved. </summary>
+    public static readonly MaterialBuilder Unknown = new MaterialBuilder("UNKNOWN")
+        .WithMetallicRoughnessShader()
+        .WithDoubleSide(true)
+        .WithBaseColor(Vector4.One);
+
     /// <summary> Build a glTF material from a hydrated XIV model, with the provided name. </summary>
     public static MaterialBuilder Export(Material material, string name, IoNotifier notifier)
     {

--- a/Penumbra/Import/Models/Export/MeshExporter.cs
+++ b/Penumbra/Import/Models/Export/MeshExporter.cs
@@ -38,7 +38,9 @@ public class MeshExporter
         public string[]                      Attributes;
     }
 
-    public static Mesh Export(ExportConfig config, MdlFile mdl, byte lod, ushort meshIndex, MaterialBuilder[] materials, GltfSkeleton? skeleton, IoNotifier notifier)
+    public static Mesh Export(in ExportConfig config, MdlFile mdl, byte lod, ushort meshIndex, MaterialBuilder[] materials,
+        GltfSkeleton? skeleton,
+        IoNotifier notifier)
     {
         var self = new MeshExporter(config, mdl, lod, meshIndex, materials, skeleton, notifier);
         return new Mesh(self.BuildMeshes(), skeleton);
@@ -65,7 +67,8 @@ public class MeshExporter
     private readonly Type _skinningType;
 
     // TODO: This signature is getting out of control.
-    private MeshExporter(ExportConfig config, MdlFile mdl, byte lod, ushort meshIndex, MaterialBuilder[] materials, GltfSkeleton? skeleton, IoNotifier notifier)
+    private MeshExporter(in ExportConfig config, MdlFile mdl, byte lod, ushort meshIndex, MaterialBuilder[] materials,
+        GltfSkeleton? skeleton, IoNotifier notifier)
     {
         _config    = config;
         _notifier  = notifier;
@@ -118,9 +121,10 @@ public class MeshExporter
                         Ensure all dependencies are enabled in the current collection, and EST entries (if required) are configured.
                         If this is a known issue with this model and you would like to export anyway, enable the ""Generate missing bones"" option."
                     );
-                
+
                 (_, gltfBoneIndex) = skeleton.GenerateBone(boneName);
-                _notifier.Warning($"Generated missing bone \"{boneName}\". Vertices weighted to this bone will not move with the rest of the armature.");
+                _notifier.Warning(
+                    $"Generated missing bone \"{boneName}\". Vertices weighted to this bone will not move with the rest of the armature.");
             }
 
             indexMap.Add((ushort)tableIndex, gltfBoneIndex);
@@ -144,7 +148,7 @@ public class MeshExporter
             .Take(XivMesh.SubMeshCount)
             .WithIndex()
             .Select(subMesh => BuildMesh($"mesh {_meshIndex}.{subMesh.Index}", indices, vertices,
-                (int)(subMesh.Value.IndexOffset - XivMesh.StartIndex), (int)subMesh.Value.IndexCount,
+                (int)(subMesh.Value.IndexOffset - XivMesh.StartIndex),         (int)subMesh.Value.IndexCount,
                 subMesh.Value.AttributeIndexMask))
             .ToArray();
     }
@@ -233,7 +237,7 @@ public class MeshExporter
 
         return new MeshData
         {
-            Mesh = meshBuilder,
+            Mesh       = meshBuilder,
             Attributes = attributes,
         };
     }

--- a/Penumbra/Import/Models/Export/ModelExporter.cs
+++ b/Penumbra/Import/Models/Export/ModelExporter.cs
@@ -55,9 +55,14 @@ public class ModelExporter
     /// <summary> Build materials for each of the material slots in the .mdl. </summary>
     private static MaterialBuilder[] ConvertMaterials(MdlFile mdl, Dictionary<string, MaterialExporter.Material> rawMaterials, IoNotifier notifier)
         => mdl.Materials
-            // TODO: material generation should be fallible, which means this lookup should be a tryget, with a fallback.
-            //       fallback can likely be a static on the material exporter.
-            .Select(name => MaterialExporter.Export(rawMaterials[name], name, notifier.WithContext($"Material {name}")))
+            .Select(name => 
+            {
+                if (rawMaterials.TryGetValue(name, out var rawMaterial))
+                    return MaterialExporter.Export(rawMaterial, name, notifier.WithContext($"Material {name}"));
+                
+                notifier.Warning($"Material \"{name}\" missing, using blank fallback.");
+                return MaterialExporter.Unknown;
+            })
             .ToArray();
 
     /// <summary> Convert XIV skeleton data into a glTF-compatible node tree, with mappings. </summary>

--- a/Penumbra/Import/Models/Export/ModelExporter.cs
+++ b/Penumbra/Import/Models/Export/ModelExporter.cs
@@ -23,16 +23,16 @@ public class ModelExporter
     }
 
     /// <summary> Export a model in preparation for usage in a glTF file. If provided, skeleton will be used to skin the resulting meshes where appropriate. </summary>
-    public static Model Export(MdlFile mdl, IEnumerable<XivSkeleton>? xivSkeleton, Dictionary<string, MaterialExporter.Material> rawMaterials)
+    public static Model Export(MdlFile mdl, IEnumerable<XivSkeleton>? xivSkeleton, Dictionary<string, MaterialExporter.Material> rawMaterials, IoNotifier notifier)
     {
         var gltfSkeleton = xivSkeleton != null ? ConvertSkeleton(xivSkeleton) : null;
-        var materials = ConvertMaterials(mdl, rawMaterials);
-        var meshes = ConvertMeshes(mdl, materials, gltfSkeleton);
+        var materials = ConvertMaterials(mdl, rawMaterials, notifier);
+        var meshes = ConvertMeshes(mdl, materials, gltfSkeleton, notifier);
         return new Model(meshes, gltfSkeleton);
     }
 
     /// <summary> Convert a .mdl to a mesh (group) per LoD. </summary>
-    private static List<MeshExporter.Mesh> ConvertMeshes(MdlFile mdl, MaterialBuilder[] materials, GltfSkeleton? skeleton)
+    private static List<MeshExporter.Mesh> ConvertMeshes(MdlFile mdl, MaterialBuilder[] materials, GltfSkeleton? skeleton, IoNotifier notifier)
     {
         var meshes = new List<MeshExporter.Mesh>();
 
@@ -43,7 +43,8 @@ public class ModelExporter
             // TODO: consider other types of mesh?
             for (ushort meshOffset = 0; meshOffset < lod.MeshCount; meshOffset++)
             {
-                var mesh = MeshExporter.Export(mdl, lodIndex, (ushort)(lod.MeshIndex + meshOffset), materials, skeleton);
+                var meshIndex = (ushort)(lod.MeshIndex + meshOffset);
+                var mesh = MeshExporter.Export(mdl, lodIndex, meshIndex, materials, skeleton, notifier.WithContext($"Mesh {meshIndex}"));
                 meshes.Add(mesh);
             }
         }
@@ -52,11 +53,11 @@ public class ModelExporter
     }
 
     /// <summary> Build materials for each of the material slots in the .mdl. </summary>
-    private static MaterialBuilder[] ConvertMaterials(MdlFile mdl, Dictionary<string, MaterialExporter.Material> rawMaterials)
+    private static MaterialBuilder[] ConvertMaterials(MdlFile mdl, Dictionary<string, MaterialExporter.Material> rawMaterials, IoNotifier notifier)
         => mdl.Materials
             // TODO: material generation should be fallible, which means this lookup should be a tryget, with a fallback.
             //       fallback can likely be a static on the material exporter.
-            .Select(name => MaterialExporter.Export(rawMaterials[name], name))
+            .Select(name => MaterialExporter.Export(rawMaterials[name], name, notifier.WithContext($"Material {name}")))
             .ToArray();
 
     /// <summary> Convert XIV skeleton data into a glTF-compatible node tree, with mappings. </summary>

--- a/Penumbra/Import/Models/Export/ModelExporter.cs
+++ b/Penumbra/Import/Models/Export/ModelExporter.cs
@@ -23,7 +23,7 @@ public class ModelExporter
     }
 
     /// <summary> Export a model in preparation for usage in a glTF file. If provided, skeleton will be used to skin the resulting meshes where appropriate. </summary>
-    public static Model Export(ExportConfig config, MdlFile mdl, IEnumerable<XivSkeleton> xivSkeletons, Dictionary<string, MaterialExporter.Material> rawMaterials, IoNotifier notifier)
+    public static Model Export(in ExportConfig config, MdlFile mdl, IEnumerable<XivSkeleton> xivSkeletons, Dictionary<string, MaterialExporter.Material> rawMaterials, IoNotifier notifier)
     {
         var gltfSkeleton = ConvertSkeleton(xivSkeletons);
         var materials = ConvertMaterials(mdl, rawMaterials, notifier);
@@ -32,7 +32,7 @@ public class ModelExporter
     }
 
     /// <summary> Convert a .mdl to a mesh (group) per LoD. </summary>
-    private static List<MeshExporter.Mesh> ConvertMeshes(ExportConfig config, MdlFile mdl, MaterialBuilder[] materials, GltfSkeleton? skeleton, IoNotifier notifier)
+    private static List<MeshExporter.Mesh> ConvertMeshes(in ExportConfig config, MdlFile mdl, MaterialBuilder[] materials, GltfSkeleton? skeleton, IoNotifier notifier)
     {
         var meshes = new List<MeshExporter.Mesh>();
 

--- a/Penumbra/Import/Models/Export/ModelExporter.cs
+++ b/Penumbra/Import/Models/Export/ModelExporter.cs
@@ -23,16 +23,16 @@ public class ModelExporter
     }
 
     /// <summary> Export a model in preparation for usage in a glTF file. If provided, skeleton will be used to skin the resulting meshes where appropriate. </summary>
-    public static Model Export(MdlFile mdl, IEnumerable<XivSkeleton>? xivSkeleton, Dictionary<string, MaterialExporter.Material> rawMaterials, IoNotifier notifier)
+    public static Model Export(ExportConfig config, MdlFile mdl, IEnumerable<XivSkeleton> xivSkeletons, Dictionary<string, MaterialExporter.Material> rawMaterials, IoNotifier notifier)
     {
-        var gltfSkeleton = xivSkeleton != null ? ConvertSkeleton(xivSkeleton) : null;
+        var gltfSkeleton = ConvertSkeleton(xivSkeletons);
         var materials = ConvertMaterials(mdl, rawMaterials, notifier);
-        var meshes = ConvertMeshes(mdl, materials, gltfSkeleton, notifier);
+        var meshes = ConvertMeshes(config, mdl, materials, gltfSkeleton, notifier);
         return new Model(meshes, gltfSkeleton);
     }
 
     /// <summary> Convert a .mdl to a mesh (group) per LoD. </summary>
-    private static List<MeshExporter.Mesh> ConvertMeshes(MdlFile mdl, MaterialBuilder[] materials, GltfSkeleton? skeleton, IoNotifier notifier)
+    private static List<MeshExporter.Mesh> ConvertMeshes(ExportConfig config, MdlFile mdl, MaterialBuilder[] materials, GltfSkeleton? skeleton, IoNotifier notifier)
     {
         var meshes = new List<MeshExporter.Mesh>();
 
@@ -44,7 +44,7 @@ public class ModelExporter
             for (ushort meshOffset = 0; meshOffset < lod.MeshCount; meshOffset++)
             {
                 var meshIndex = (ushort)(lod.MeshIndex + meshOffset);
-                var mesh = MeshExporter.Export(mdl, lodIndex, meshIndex, materials, skeleton, notifier.WithContext($"Mesh {meshIndex}"));
+                var mesh = MeshExporter.Export(config, mdl, lodIndex, meshIndex, materials, skeleton, notifier.WithContext($"Mesh {meshIndex}"));
                 meshes.Add(mesh);
             }
         }
@@ -105,7 +105,7 @@ public class ModelExporter
         return new GltfSkeleton
         {
             Root = root,
-            Joints = [.. joints],
+            Joints = joints,
             Names = names,
         };
     }

--- a/Penumbra/Import/Models/Export/ModelExporter.cs
+++ b/Penumbra/Import/Models/Export/ModelExporter.cs
@@ -59,7 +59,7 @@ public class ModelExporter
             {
                 if (rawMaterials.TryGetValue(name, out var rawMaterial))
                     return MaterialExporter.Export(rawMaterial, name, notifier.WithContext($"Material {name}"));
-                
+
                 notifier.Warning($"Material \"{name}\" missing, using blank fallback.");
                 return MaterialExporter.Unknown;
             })

--- a/Penumbra/Import/Models/Export/Skeleton.cs
+++ b/Penumbra/Import/Models/Export/Skeleton.cs
@@ -28,8 +28,18 @@ public struct GltfSkeleton
     public NodeBuilder Root;
 
     /// <summary> Flattened list of skeleton nodes. </summary>
-    public NodeBuilder[] Joints;
+    public List<NodeBuilder> Joints;
 
     /// <summary> Mapping of bone names to their index within the joints array. </summary>
     public Dictionary<string, int> Names;
+
+    public (NodeBuilder, int) GenerateBone(string name)
+    {
+        var node = new NodeBuilder(name);
+        var index = Joints.Count;
+        Names[name] = index;
+        Joints.Add(node);
+        Root.AddNode(node);
+        return (node, index);
+    }
 }

--- a/Penumbra/Import/Models/Import/MeshImporter.cs
+++ b/Penumbra/Import/Models/Import/MeshImporter.cs
@@ -216,7 +216,7 @@ public class MeshImporter(IEnumerable<Node> nodes, IoNotifier notifier)
 
         // Per glTF specification, an asset with a skin MUST contain skinning attributes on its mesh.
         var jointsAccessor = primitive.GetVertexAccessor("JOINTS_0")
-         ?? throw notifier.Exception($"Skinned mesh \"{meshName}\" is skinned but does not contain skinning vertex attributes.");
+         ?? throw notifier.Exception($"Mesh \"{meshName}\" is skinned but does not contain skinning vertex attributes.");
 
         // Build a set of joints that are referenced by this mesh.
         // TODO: Would be neat to omit 0-weighted joints here, but doing so will require some further work on bone mapping behavior to ensure the unweighted joints can still be resolved to valid bone indices during vertex data construction.

--- a/Penumbra/Import/Models/Import/MeshImporter.cs
+++ b/Penumbra/Import/Models/Import/MeshImporter.cs
@@ -3,7 +3,7 @@ using SharpGLTF.Schema2;
 
 namespace Penumbra.Import.Models.Import;
 
-public class MeshImporter(IEnumerable<Node> nodes)
+public class MeshImporter(IEnumerable<Node> nodes, IoNotifier notifier)
 {
     public struct Mesh
     {
@@ -33,9 +33,9 @@ public class MeshImporter(IEnumerable<Node> nodes)
         public List<MdlStructs.ShapeValueStruct> ShapeValues;
     }
 
-    public static Mesh Import(IEnumerable<Node> nodes)
+    public static Mesh Import(IEnumerable<Node> nodes, IoNotifier notifier)
     {
-        var importer = new MeshImporter(nodes);
+        var importer = new MeshImporter(nodes, notifier);
         return importer.Create();
     }
 
@@ -115,10 +115,10 @@ public class MeshImporter(IEnumerable<Node> nodes)
         var vertexOffset = _vertexCount;
         var indexOffset  = _indices.Count;
 
-        var nodeBoneMap = CreateNodeBoneMap(node);
-        var subMesh     = SubMeshImporter.Import(node, nodeBoneMap);
-
         var subMeshName = node.Name ?? node.Mesh.Name;
+
+        var nodeBoneMap = CreateNodeBoneMap(node);
+        var subMesh     = SubMeshImporter.Import(node, nodeBoneMap, notifier.WithContext($"Sub-mesh {subMeshName}"));
 
         // TODO: Record a warning if there's a mismatch between current and incoming, as we can't support multiple materials per mesh.
         _material ??= subMesh.Material;
@@ -127,8 +127,11 @@ public class MeshImporter(IEnumerable<Node> nodes)
         if (_vertexDeclaration == null)
             _vertexDeclaration = subMesh.VertexDeclaration;
         else if (VertexDeclarationMismatch(subMesh.VertexDeclaration, _vertexDeclaration.Value))
-            throw new Exception(
-                $"Sub-mesh \"{subMeshName}\" vertex declaration mismatch. All sub-meshes of a mesh must have equivalent vertex declarations.");
+            throw notifier.Exception(
+                $@"All sub-meshes of a mesh must have equivalent vertex declarations.
+                Current: {FormatVertexDeclaration(_vertexDeclaration.Value)}
+                Sub-mesh ""{subMeshName}"": {FormatVertexDeclaration(subMesh.VertexDeclaration)}"
+            );
 
         // Given that strides are derived from declarations, a lack of mismatch in declarations means the strides are fine.
         // TODO: I mean, given that strides are derivable, might be worth dropping strides from the sub mesh return structure and computing when needed.
@@ -170,6 +173,9 @@ public class MeshImporter(IEnumerable<Node> nodes)
         });
     }
 
+    private static string FormatVertexDeclaration(MdlStructs.VertexDeclarationStruct vertexDeclaration)
+        => string.Join(", ", vertexDeclaration.VertexElements.Select(element => $"{element.Usage} ({element.Type}@{element.Stream}:{element.Offset})"));
+
     private static bool VertexDeclarationMismatch(MdlStructs.VertexDeclarationStruct a, MdlStructs.VertexDeclarationStruct b)
     {
         var elA = a.VertexElements;
@@ -204,13 +210,13 @@ public class MeshImporter(IEnumerable<Node> nodes)
         var meshName       = node.Name ?? mesh.Name ?? "(no name)";
         var primitiveCount = mesh.Primitives.Count;
         if (primitiveCount != 1)
-            throw new Exception($"Mesh \"{meshName}\" has {primitiveCount} primitives, expected 1.");
+            throw notifier.Exception($"Mesh \"{meshName}\" has {primitiveCount} primitives, expected 1.");
 
         var primitive = mesh.Primitives[0];
 
         // Per glTF specification, an asset with a skin MUST contain skinning attributes on its mesh.
         var jointsAccessor = primitive.GetVertexAccessor("JOINTS_0")
-         ?? throw new Exception($"Skinned mesh \"{meshName}\" is skinned but does not contain skinning vertex attributes.");
+         ?? throw notifier.Exception($"Skinned mesh \"{meshName}\" is skinned but does not contain skinning vertex attributes.");
 
         // Build a set of joints that are referenced by this mesh.
         // TODO: Would be neat to omit 0-weighted joints here, but doing so will require some further work on bone mapping behavior to ensure the unweighted joints can still be resolved to valid bone indices during vertex data construction.

--- a/Penumbra/Import/Models/IoNotifier.cs
+++ b/Penumbra/Import/Models/IoNotifier.cs
@@ -1,0 +1,52 @@
+using Dalamud.Interface.Internal.Notifications;
+using OtterGui.Classes;
+
+namespace Penumbra.Import.Models;
+
+public record class IoNotifier
+{
+    /// <summary> Notification subclass so that we have a distinct type to filter by. </summary>
+    private class LegallyDistinctNotification : Notification
+    {
+        public LegallyDistinctNotification(string content, NotificationType type): base(content, type)
+        {}
+    }
+
+    private readonly DateTime _startTime = DateTime.UtcNow;
+    private          string   _context   = "";
+
+    /// <summary> Create a new notifier with the specified context appended to any other context already present. </summary>
+    public IoNotifier WithContext(string context)
+        => this with { _context = $"{_context}{context}: "};
+
+    /// <summary> Send a warning with any current context to notification channels. </summary>
+    public void Warning(string content)
+        => SendNotification(content, NotificationType.Warning);
+
+    /// <summary> Get the current warnings for this notifier. </summary>
+    /// <remarks> This does not currently filter to notifications with the current notifier's context - it will return all IO notifications from all notifiers. </remarks>
+    public IEnumerable<string> GetWarnings()
+        => GetFilteredNotifications(NotificationType.Warning);
+
+    /// <summary> Create an exception with any current context. </summary>
+    [StackTraceHidden]
+    public Exception Exception(string message)
+        => Exception<Exception>(message);
+
+    /// <summary> Create an exception of the provided type with any current context. </summary>
+    [StackTraceHidden]
+    public TException Exception<TException>(string message)
+        where TException : Exception, new()
+        => (TException)Activator.CreateInstance(typeof(TException), $"{_context}{message}")!;
+
+    private void SendNotification(string message, NotificationType type)
+        => Penumbra.Messager.AddMessage(
+            new LegallyDistinctNotification($"{_context}{message}", type),
+            true, false, true, false
+        );
+
+    private IEnumerable<string> GetFilteredNotifications(NotificationType type)
+        => Penumbra.Messager
+            .Where(p => p.Key >= _startTime && p.Value is LegallyDistinctNotification && p.Value.NotificationType == type)
+            .Select(p => p.Value.PrintMessage);
+}

--- a/Penumbra/Import/Models/ModelManager.cs
+++ b/Penumbra/Import/Models/ModelManager.cs
@@ -43,10 +43,10 @@ public sealed class ModelManager(IFramework framework, ActiveCollections collect
             action => action.Notifier
         );
 
-    public Task<MdlFile?> ImportGltf(string inputPath)
+    public Task<(MdlFile?, IoNotifier)> ImportGltf(string inputPath)
         => EnqueueWithResult(
             new ImportGltfAction(inputPath),
-            action => action.Out
+            action => (action.Out, action.Notifier)
         );
 
     /// <summary> Try to find the .sklb paths for a .mdl file. </summary>
@@ -273,12 +273,13 @@ public sealed class ModelManager(IFramework framework, ActiveCollections collect
     private partial class ImportGltfAction(string inputPath) : IAction
     {
         public MdlFile? Out;
+        public IoNotifier Notifier = new IoNotifier();
 
         public void Execute(CancellationToken cancel)
         {
             var model = Schema2.ModelRoot.Load(inputPath);
 
-            Out = ModelImporter.Import(model);
+            Out = ModelImporter.Import(model, Notifier);
         }
 
         public bool Equals(IAction? other)

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
@@ -260,7 +260,7 @@ public partial class ModEditWindow
         /// <summary> Read a file from the active collection or game. </summary>
         /// <param name="path"> Game path to the file to load. </param>
         // TODO: Also look up files within the current mod regardless of mod state?
-        private byte[] ReadFile(string path)
+        private byte[]? ReadFile(string path)
         {
             // TODO: if cross-collection lookups are turned off, this conversion can be skipped
             if (!Utf8GamePath.FromString(path, out var utf8Path, true))
@@ -269,13 +269,9 @@ public partial class ModEditWindow
             var resolvedPath = _edit._activeCollections.Current.ResolvePath(utf8Path) ?? new FullPath(utf8Path);
 
             // TODO: is it worth trying to use streams for these instead? I'll need to do this for mtrl/tex too, so might be a good idea. that said, the mtrl reader doesn't accept streams, so...
-            var bytes = resolvedPath.IsRooted
+            return resolvedPath.IsRooted
                 ? File.ReadAllBytes(resolvedPath.FullName)
                 : _edit._gameData.GetFile(resolvedPath.InternalName.ToString())?.Data;
-
-            // TODO: some callers may not care about failures - handle exceptions separately?
-            return bytes ?? throw new Exception(
-                $"Resolved path {path} could not be found. If modded, is it enabled in the current collection?");
         }
 
         /// <summary> Remove the material given by the index. </summary>

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
@@ -3,6 +3,7 @@ using OtterGui;
 using Penumbra.GameData;
 using Penumbra.GameData.Files;
 using Penumbra.Import.Models;
+using Penumbra.Import.Models.Export;
 using Penumbra.Meta.Manipulations;
 using Penumbra.String.Classes;
 
@@ -19,6 +20,8 @@ public partial class ModEditWindow
 
         public bool ImportKeepMaterials;
         public bool ImportKeepAttributes;
+
+        public ExportConfig ExportConfig;
 
         public List<Utf8GamePath>? GamePaths { get; private set; }
         public int                 GamePathIndex;
@@ -131,7 +134,7 @@ public partial class ModEditWindow
             }
 
             PendingIo = true;
-            _edit._models.ExportToGltf(Mdl, sklbPaths, ReadFile, outputPath)
+            _edit._models.ExportToGltf(ExportConfig, Mdl, sklbPaths, ReadFile, outputPath)
                 .ContinueWith(task =>
                 {
                     RecordIoExceptions(task.Exception);

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
@@ -134,6 +134,8 @@ public partial class ModEditWindow
                 .ContinueWith(task =>
                 {
                     RecordIoExceptions(task.Exception);
+                    if (task is { IsCompletedSuccessfully: true, Result: not null })
+                        IoWarnings = task.Result.GetWarnings().ToList();
                     PendingIo   = false;
                 });
         }

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
@@ -2,6 +2,7 @@ using Lumina.Data.Parsing;
 using OtterGui;
 using Penumbra.GameData;
 using Penumbra.GameData.Files;
+using Penumbra.Import.Models;
 using Penumbra.Meta.Manipulations;
 using Penumbra.String.Classes;
 
@@ -146,11 +147,14 @@ public partial class ModEditWindow
         {
             PendingIo = true;
             _edit._models.ImportGltf(inputPath)
-                .ContinueWith(task =>
+                .ContinueWith((Task<(MdlFile?, IoNotifier)> task) =>
                 {
                     RecordIoExceptions(task.Exception);
-                    if (task is { IsCompletedSuccessfully: true, Result: not null })
-                        FinalizeImport(task.Result);
+                    if (task is { IsCompletedSuccessfully: true, Result: (not null, _) })
+                    {
+                        IoWarnings = task.Result.Item2.GetWarnings().ToList();
+                        FinalizeImport(task.Result.Item1);
+                    }
                     PendingIo = false;
                 });
         }

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
@@ -25,6 +25,7 @@ public partial class ModEditWindow
         private bool            _dirty;
         public  bool            PendingIo    { get; private set; }
         public  List<Exception> IoExceptions { get; private set; } = [];
+        public  List<string>    IoWarnings   { get; private set; } = [];
 
         public MdlTab(ModEditWindow edit, byte[] bytes, string path)
         {

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -112,7 +112,6 @@ public partial class ModEditWindow
 
         DrawGamePathCombo(tab);
 
-        // ImGui.Checkbox("##exportGeneratedMissingBones", ref tab.ExportGenerateMissingBones);
         ImGui.Checkbox("##exportGeneratedMissingBones", ref tab.ExportConfig.GenerateMissingBones);
         ImGui.SameLine();
         ImGuiUtil.LabeledHelpMarker("Generate missing bones",

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -63,6 +63,7 @@ public partial class ModEditWindow
         DrawExport(tab, childSize, disabled);
 
         DrawIoExceptions(tab);
+        DrawIoWarnings(tab);
     }
 
     private void DrawImport(MdlTab tab, Vector2 size, bool _1)
@@ -148,7 +149,43 @@ public partial class ModEditWindow
 
             using var exceptionNode = ImRaii.TreeNode(message);
             if (exceptionNode)
+            {
+                ImGui.Dummy(new Vector2(ImGui.GetStyle().IndentSpacing, 0));
+                ImGui.SameLine();
                 ImGuiUtil.TextWrapped(exception.ToString());
+            }
+        }
+    }
+
+    private static void DrawIoWarnings(MdlTab tab)
+    {
+        if (tab.IoWarnings.Count == 0)
+            return;
+
+        var size = new Vector2(ImGui.GetContentRegionAvail().X, 0);
+        using var frame = ImRaii.FramedGroup("Warnings", size, headerPreIcon: FontAwesomeIcon.ExclamationCircle, borderColor: 0xFF40FFFF);
+
+        var spaceAvail = ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X - 100;
+        foreach (var (warning, index) in tab.IoWarnings.WithIndex())
+        {
+            using var id       = ImRaii.PushId(index);
+            var       textSize = ImGui.CalcTextSize(warning).X;
+
+            if (textSize <= spaceAvail)
+            {
+                ImRaii.TreeNode(warning, ImGuiTreeNodeFlags.Leaf).Dispose();
+                continue;
+            }
+
+            var firstLine = warning[..(int)Math.Floor(warning.Length * (spaceAvail / textSize))] + "...";
+
+            using var warningNode = ImRaii.TreeNode(firstLine);
+            if (warningNode)
+            {
+                ImGui.Dummy(new Vector2(ImGui.GetStyle().IndentSpacing, 0));
+                ImGui.SameLine();
+                ImGuiUtil.TextWrapped(warning.ToString());
+            }
         }
     }
 

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -112,6 +112,14 @@ public partial class ModEditWindow
 
         DrawGamePathCombo(tab);
 
+        // ImGui.Checkbox("##exportGeneratedMissingBones", ref tab.ExportGenerateMissingBones);
+        ImGui.Checkbox("##exportGeneratedMissingBones", ref tab.ExportConfig.GenerateMissingBones);
+        ImGui.SameLine();
+        ImGuiUtil.LabeledHelpMarker("Generate missing bones",
+            "WARNING: Enabling this option can result in unusable exported meshes.\n"
+          + "It is primarily intended to allow exporting models weighted to bones that do not exist.\n"
+          + "Before enabling, ensure dependencies are enabled in the current collection, and EST metadata is correctly configured.");
+
         var gamePath = tab.GamePathIndex >= 0 && tab.GamePathIndex < tab.GamePaths.Count
             ? tab.GamePaths[tab.GamePathIndex]
             : _customGamePath;

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -170,8 +170,7 @@ public partial class ModEditWindow
             using var exceptionNode = ImRaii.TreeNode(message);
             if (exceptionNode)
             {
-                ImGui.Dummy(new Vector2(ImGui.GetStyle().IndentSpacing, 0));
-                ImGui.SameLine();
+                using var indent = ImRaii.PushIndent();
                 ImGuiUtil.TextWrapped(exception.ToString());
             }
         }
@@ -202,9 +201,8 @@ public partial class ModEditWindow
             using var warningNode = ImRaii.TreeNode(firstLine);
             if (warningNode)
             {
-                ImGui.Dummy(new Vector2(ImGui.GetStyle().IndentSpacing, 0));
-                ImGui.SameLine();
-                ImGuiUtil.TextWrapped(warning.ToString());
+                using var indent = ImRaii.PushIndent();
+                ImGuiUtil.TextWrapped(warning);
             }
         }
     }


### PR DESCRIPTION
This pr:
- Adds infrastructure for warnings. These are collated, and returned at the end of an io operation, then shown in the same place errors would be. The class collating the warnings also provide the ability to create a copy of itself referencing the same warning list, but with a built "context" that allows warnings (and exceptions) to contain contextual information without wiring that information into every single method.
- Uses the above to allow material export to fail-soft.
- Uses the above to allow (opt-in) missing bones to fail-soft.