### PR TITLE
.mdl io: Triage pass 2

### DIFF
--- a/Penumbra/Import/Models/Import/ModelImporter.cs
+++ b/Penumbra/Import/Models/Import/ModelImporter.cs
@@ -134,7 +134,6 @@ public partial class ModelImporter(ModelRoot model)
         var subMeshOffset    = _subMeshes.Count;
         var vertexOffset     = _vertexBuffer.Count;
         var indexOffset      = _indices.Count;
-        var shapeValueOffset = _shapeValues.Count;
 
         var mesh           = MeshImporter.Import(subMeshNodes);
         var meshStartIndex = (uint)(mesh.MeshStruct.StartIndex + indexOffset);
@@ -184,7 +183,7 @@ public partial class ModelImporter(ModelRoot model)
             shapeMeshes.Add(meshShapeKey.ShapeMesh with
             {
                 MeshIndexOffset = meshStartIndex,
-                ShapeValueOffset = (uint)shapeValueOffset,
+                ShapeValueOffset = (uint)_shapeValues.Count,
             });
 
             _shapeValues.AddRange(meshShapeKey.ShapeValues);

--- a/Penumbra/Import/Models/Import/SubMeshImporter.cs
+++ b/Penumbra/Import/Models/Import/SubMeshImporter.cs
@@ -234,7 +234,7 @@ public class SubMeshImporter
 
         foreach (var (modifiedVertices, morphIndex) in morphModifiedVertices.WithIndex())
         {
-            // Each for a given mesh, each shape key contains a list of shape value mappings.
+            // For a given mesh, each shape key contains a list of shape value mappings.
             var shapeValues = new List<MdlStructs.ShapeValueStruct>();
 
             foreach (var vertexIndex in modifiedVertices)

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -326,7 +326,7 @@ public partial class ModEditWindow
 
         // Sub meshes
         for (var subMeshOffset = 0; subMeshOffset < mesh.SubMeshCount; subMeshOffset++)
-            ret |= DrawSubMeshAttributes(tab, meshIndex, disabled, subMeshOffset);
+            ret |= DrawSubMeshAttributes(tab, meshIndex, subMeshOffset, disabled);
 
         return ret;
     }
@@ -354,7 +354,7 @@ public partial class ModEditWindow
         return ret;
     }
 
-    private bool DrawSubMeshAttributes(MdlTab tab, int meshIndex, bool disabled, int subMeshOffset)
+    private bool DrawSubMeshAttributes(MdlTab tab, int meshIndex, int subMeshOffset, bool disabled)
     {
         using var _ = ImRaii.PushId(subMeshOffset);
 
@@ -368,6 +368,12 @@ public partial class ModEditWindow
         ImGui.TableNextColumn();
         var widget     = _subMeshAttributeTagWidgets[subMeshIndex];
         var attributes = tab.GetSubMeshAttributes(subMeshIndex);
+
+        if (attributes == null)
+        {
+            attributes = ["invalid attribute data"];
+            disabled = true;
+        }
 
         var tagIndex = widget.Draw(string.Empty, string.Empty, attributes,
             out var editedAttribute, !disabled);

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -386,6 +386,8 @@ public partial class ModEditWindow
         if (!ImGui.CollapsingHeader("Further Content"))
             return false;
 
+        using var furtherContentId = ImRaii.PushId("furtherContent");
+
         using (var table = ImRaii.Table("##data", 2, ImGuiTableFlags.SizingFixedFit))
         {
             if (table)

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -1,6 +1,7 @@
 using Dalamud.Interface;
 using ImGuiNET;
 using OtterGui;
+using OtterGui.Custom;
 using OtterGui.Raii;
 using OtterGui.Widgets;
 using Penumbra.GameData;
@@ -13,7 +14,9 @@ namespace Penumbra.UI.AdvancedWindow;
 
 public partial class ModEditWindow
 {
-    private const int MdlMaterialMaximum = 4;
+    private const int    MdlMaterialMaximum     = 4;
+    private const string MdlImportDocumentation = @"https://github.com/xivdev/Penumbra/wiki/Model-IO#import";
+    private const string MdlExportDocumentation = @"https://github.com/xivdev/Penumbra/wiki/Model-IO#export";
 
     private readonly FileEditor<MdlTab> _modelTab;
     private readonly ModelManager       _models;
@@ -67,6 +70,8 @@ public partial class ModEditWindow
 
     private void DrawImport(MdlTab tab, Vector2 size, bool _1)
     {
+        using var id = ImRaii.PushId("import");
+
         _dragDropManager.CreateImGuiSource("ModelDragDrop",
             m => m.Extensions.Any(e => ValidModelExtensions.Contains(e.ToLowerInvariant())), m =>
             {
@@ -89,6 +94,9 @@ public partial class ModEditWindow
                     if (success && paths.Count > 0)
                         tab.Import(paths[0]);
                 }, 1, _mod!.ModPath.FullName, false);
+
+            ImGui.SameLine();
+            DrawDocumentationLink(MdlImportDocumentation);
         }
 
         if (_dragDropManager.CreateImGuiTarget("ModelDragDrop", out var files, out _) && GetFirstModel(files, out var importFile))
@@ -97,6 +105,7 @@ public partial class ModEditWindow
 
     private void DrawExport(MdlTab tab, Vector2 size, bool _)
     {
+        using var id    = ImRaii.PushId("export");
         using var frame = ImRaii.FramedGroup("Export", size, headerPreIcon: FontAwesomeIcon.FileExport);
 
         if (tab.GamePaths == null)
@@ -110,10 +119,10 @@ public partial class ModEditWindow
         }
 
         DrawGamePathCombo(tab);
-
         var gamePath = tab.GamePathIndex >= 0 && tab.GamePathIndex < tab.GamePaths.Count
             ? tab.GamePaths[tab.GamePathIndex]
             : _customGamePath;
+
         if (ImGuiUtil.DrawDisabledButton("Export to glTF", Vector2.Zero, "Exports this mdl file to glTF, for use in 3D authoring applications.",
                 tab.PendingIo || gamePath.IsEmpty))
             _fileDialog.OpenSavePicker("Save model as glTF.", ".gltf", Path.GetFileNameWithoutExtension(gamePath.Filename().ToString()),
@@ -127,6 +136,9 @@ public partial class ModEditWindow
                 _mod!.ModPath.FullName,
                 false
             );
+
+        ImGui.SameLine();
+        DrawDocumentationLink(MdlExportDocumentation);
     }
     
     private static void DrawIoExceptions(MdlTab tab)
@@ -203,6 +215,24 @@ public partial class ModEditWindow
         if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
             ImGui.SetClipboardText(preview);
         ImGuiUtil.HoverTooltip("Right-Click to copy to clipboard.", ImGuiHoveredFlags.AllowWhenDisabled);
+    }
+
+    private void DrawDocumentationLink(string address)
+    {
+        const string text = "Documentation →";
+
+        var framePadding = ImGui.GetStyle().FramePadding;
+        var width        = ImGui.CalcTextSize(text).X + framePadding.X * 2;
+
+        // Draw the link button. We set the background colour to transparent to mimic the look of a link.
+        using var color = ImRaii.PushColor(ImGuiCol.Button, 0x00000000);
+        CustomGui.DrawLinkButton(Penumbra.Messager, text, address, width);
+
+        // Draw an underline for the text.
+        var lineStart = ImGui.GetItemRectMax();
+        lineStart -= framePadding;
+        var lineEnd = lineStart with { X = ImGui.GetItemRectMin().X + framePadding.X };
+        ImGui.GetWindowDrawList().AddLine(lineStart, lineEnd, 0xFFFFFFFF);
     }
 
     private bool DrawModelMaterialDetails(MdlTab tab, bool disabled)


### PR DESCRIPTION
**requires https://github.com/Ottermandias/OtterGui/pull/6**

Another collection of smaller fixes.

- ae409c2cd1732f8889949d5f10865703285441b9: Fixes a dumb mistake I made that caused imported shape keys to be completely incorrect for anything but the first shape key per mesh. Didn't notice it originally because i happened to be testing with the first key, whoops.
- c11519c95ef223bd4964bfd94739dfecc470012a: The material section and the material group in the further content section were sharing an ID. Just scoping the further content with a pushed id.
- 655d1722c18fbd24b5a569129c6005c439d7102d: [bug report](https://discord.com/channels/884363610640498698/1198111315437309952). some bgpart models have attribute masks but no attributes. this just makes that fail-soft, but not sure if it's garbage data or a data union which they use for other things on attribute-less models.
- a38db004787d6474b557760e95f1bed2a5b09fd2: adds documentation links to import and export. they're both links to sections on https://github.com/xivdev/Penumbra/wiki/Model-IO, which i'll be expanding over time.