### PR TITLE
.mdl io: Triage pass 4

### DIFF
--- a/Penumbra/Import/Models/Export/MeshExporter.cs
+++ b/Penumbra/Import/Models/Export/MeshExporter.cs
@@ -230,10 +230,19 @@ public class MeshExporter
             { "targetNames", shapeNames },
         });
 
-        var attributes = Enumerable.Range(0, 32)
-            .Where(index => ((attributeMask >> index) & 1) == 1)
-            .Select(index => _mdl.Attributes[index])
-            .ToArray();
+        string[] attributes = [];
+        var maxAttribute = 31 - BitOperations.LeadingZeroCount(attributeMask);
+        if (maxAttribute < _mdl.Attributes.Length)
+        {
+            attributes = Enumerable.Range(0, 32)
+                .Where(index => ((attributeMask >> index) & 1) == 1)
+                .Select(index => _mdl.Attributes[index])
+                .ToArray();
+        }
+        else
+        {
+            _notifier.Warning($"Invalid attribute data, ignoring.");
+        }
 
         return new MeshData
         {

--- a/Penumbra/Import/Models/Export/VertexFragment.cs
+++ b/Penumbra/Import/Models/Export/VertexFragment.cs
@@ -11,7 +11,8 @@ and there's reason to overhaul the export pipeline.
 
 public struct VertexColorFfxiv : IVertexCustom
 {
-    [VertexAttribute("_FFXIV_COLOR", EncodingType.UNSIGNED_BYTE, false)]
+    // NOTE: We only realistically require UNSIGNED_BYTE for this, however Blender 3.6 errors on that (fixed in 4.0).
+    [VertexAttribute("_FFXIV_COLOR", EncodingType.UNSIGNED_SHORT, false)]
     public Vector4 FfxivColor;
 
     public int MaxColors => 0;
@@ -80,7 +81,7 @@ public struct VertexTexture1ColorFfxiv : IVertexCustom
     [VertexAttribute("TEXCOORD_0")]
     public Vector2 TexCoord0;
 
-    [VertexAttribute("_FFXIV_COLOR", EncodingType.UNSIGNED_BYTE, false)]
+    [VertexAttribute("_FFXIV_COLOR", EncodingType.UNSIGNED_SHORT, false)]
     public Vector4 FfxivColor;
 
     public int MaxColors => 0;
@@ -162,7 +163,7 @@ public struct VertexTexture2ColorFfxiv : IVertexCustom
     [VertexAttribute("TEXCOORD_1")]
     public Vector2 TexCoord1;
 
-    [VertexAttribute("_FFXIV_COLOR", EncodingType.UNSIGNED_BYTE, false)]
+    [VertexAttribute("_FFXIV_COLOR", EncodingType.UNSIGNED_SHORT, false)]
     public Vector4 FfxivColor;
 
     public int MaxColors => 0;


### PR DESCRIPTION
triage number goes brr

- 6693a1e0bad504916906aa161cec69365fcbb8a6: noticed that warnings/errors were sticking around if they weren't overwritten by the next op. pulled the begin/finalise logic out so I don't have to keep updating it at every callsite
- 72775a80bfbcc1b7c7ab06827f1caf6722195a9d: this is already being done in the ui view, forgot to do it in the export. i'll deduplicate this when i build the intermediary format.
- 1649da70a899fa90ad3ced2a37ff1d8e726b0a16: turns out blender 3.6 doesn't support custom `UNSIGNED_BYTE`s, but does support `UNSIGNED_SHORT` so hey there we go i guess
- e9628afaf84ac8afc24eaeddc5a92f12c00e3f2f: blender 3.6's material handling doesn't really know what to do if you give it a specular tint but no factor, and ends up exporting invalid gltf data. this just adds the specular factor (which is almost always 1.0) to the gltf + spec texture, which at least means the blender material isn't bugging out. this does make it look a bit... _shiny_ in 3.6, but it's fine in 4.0 and frankly if that's a problem it's easy to fix in blender.