### PR TITLE
.mdl io: Triage pass 5

### DIFF
--- a/Penumbra/Import/Models/Export/MeshExporter.cs
+++ b/Penumbra/Import/Models/Export/MeshExporter.cs
@@ -214,10 +214,18 @@ public class MeshExporter
             var morphBuilder = meshBuilder.UseMorphTarget(shapeNames.Count);
             shapeNames.Add(shape.ShapeName);
 
-            foreach (var shapeValue in shapeValues)
+            foreach (var (shapeValue, shapeValueIndex) in shapeValues.WithIndex())
             {
+                var gltfIndex = gltfIndices[shapeValue.BaseIndicesIndex - indexBase];
+
+                if (gltfIndex == -1)
+                {
+                    _notifier.Warning($"{name}: Shape {shape.ShapeName} mapping {shapeValueIndex} targets a degenerate triangle, ignoring.");
+                    continue;
+                }
+
                 morphBuilder.SetVertex(
-                    primitiveVertices[gltfIndices[shapeValue.BaseIndicesIndex - indexBase]].GetGeometry(),
+                    primitiveVertices[gltfIndex].GetGeometry(),
                     vertices[shapeValue.ReplacingVertexIndex].GetGeometry()
                 );
             }

--- a/Penumbra/Import/Models/Import/MeshImporter.cs
+++ b/Penumbra/Import/Models/Import/MeshImporter.cs
@@ -80,7 +80,6 @@ public class MeshImporter(IEnumerable<Node> nodes, IoNotifier notifier)
                 StartIndex = 0,
                 IndexCount = (uint)_indices.Count,
 
-                // TODO: import material names
                 MaterialIndex  = 0,
                 SubMeshIndex   = 0,
                 SubMeshCount   = (ushort)_subMeshes.Count,

--- a/Penumbra/Import/Models/Import/MeshImporter.cs
+++ b/Penumbra/Import/Models/Import/MeshImporter.cs
@@ -167,7 +167,7 @@ public class MeshImporter(IEnumerable<Node> nodes, IoNotifier notifier)
         // And finally, merge in the sub-mesh struct itself.
         _subMeshes.Add(subMesh.SubMeshStruct with
         {
-            IndexOffset = (ushort)(subMesh.SubMeshStruct.IndexOffset + indexOffset),
+            IndexOffset = (uint)(subMesh.SubMeshStruct.IndexOffset + indexOffset),
             AttributeIndexMask = Utility.GetMergedAttributeMask(
                 subMesh.SubMeshStruct.AttributeIndexMask, subMesh.MetaAttributes, _metaAttributes),
         });

--- a/Penumbra/Import/Models/Import/Utility.cs
+++ b/Penumbra/Import/Models/Import/Utility.cs
@@ -1,4 +1,5 @@
 using Lumina.Data.Parsing;
+using Penumbra.GameData.Files;
 
 namespace Penumbra.Import.Models.Import;
 
@@ -43,15 +44,15 @@ public static class Utility
             throw notifier.Exception(
                 $"""
                  All sub-meshes of a mesh must have equivalent vertex declarations.
-                                 Current: {FormatVertexDeclaration(current)}
-                                 New:     {FormatVertexDeclaration(@new)}
+                 Current: {FormatVertexDeclaration(current)}
+                 New:     {FormatVertexDeclaration(@new)}
                  """
             );
     }
 
     private static string FormatVertexDeclaration(MdlStructs.VertexDeclarationStruct vertexDeclaration)
         => string.Join(", ",
-            vertexDeclaration.VertexElements.Select(element => $"{element.Usage} ({element.Type}@{element.Stream}:{element.Offset})"));
+            vertexDeclaration.VertexElements.Select(element => $"{(MdlFile.VertexUsage)element.Usage} ({(MdlFile.VertexType)element.Type}@{element.Stream}:{element.Offset})"));
 
     private static bool VertexDeclarationMismatch(MdlStructs.VertexDeclarationStruct a, MdlStructs.VertexDeclarationStruct b)
     {

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.MdlTab.cs
@@ -220,24 +220,9 @@ public partial class ModEditWindow
         /// <param name="source"> Model to copy element ids from. </param>
         private static void MergeElementIds(MdlFile target, MdlFile source)
         {
-            var elementIds = new List<MdlStructs.ElementIdStruct>();
-
-            foreach (var sourceElement in source.ElementIds)
-            {
-                var sourceBone  = source.Bones[sourceElement.ParentBoneName];
-                var targetIndex = target.Bones.IndexOf(sourceBone);
-                // Given that there's no means of authoring these at the moment, this should probably remain a hard error.
-                if (targetIndex == -1)
-                    throw new Exception(
-                        $"Failed to merge element IDs. Original model contains element IDs targeting bone {sourceBone}, which is not present on the imported model.");
-
-                elementIds.Add(sourceElement with
-                {
-                    ParentBoneName = (uint)targetIndex,
-                });
-            }
-
-            target.ElementIds = [.. elementIds];
+            // This is overly simplistic, but effectively reproduces what TT did, sort of.
+            // TODO: Get a better idea of what these values represent. `ParentBoneName`, if it is a pointer into the bone array, does not seem to be _bounded_ by the bone array length, at least in the model. I'm guessing it _may_ be pointing into a .sklb instead? (i.e. the weapon's skeleton). EID stuff in general needs more work.
+            target.ElementIds = [.. source.ElementIds];
         }
 
         private void BeginIo()


### PR DESCRIPTION
There's more fixes that need to be made but I really need to at least get this PR up so I don't leave it hanging forever. Feel free to hold off merge until cutting the next release - I'll only create the next triage branch when this one is merged.

At time of writing;

- 8e3aab58d6a2c0091573e6f09d5b8b06cc931c8b: Just makes the vertex declaration mismatch error more readable
- e9d5a11ccea82ebd5ed2808d75edafd74f4b8573: Degenerate triangles in source data aren't exported (they're junk data anyway), and sharpgltf just returns `-1` for the triangle indices. this just ensures i don't end up mucking up shape key data when there's a shape key targeting a degenerate tri
- a4edaec653e32ea1cbc44780937d21e8ffb16764: Just a mis-cast of an index value causing high-poly meshes to be cut off at `ushort.MAX_VALUE`
- dfbe8c22e5ef3d0fc951ccf327f0469f0370d979: EIDs are weird, man