### PR TITLE
Add shared tag system for tagging individual mods

### DIFF
--- a/Penumbra/Configuration.cs
+++ b/Penumbra/Configuration.cs
@@ -87,6 +87,8 @@ public class Configuration : IPluginConfiguration, ISavable
     public Dictionary<ColorId, uint> Colors { get; set; }
         = Enum.GetValues<ColorId>().ToDictionary(c => c, c => c.Data().DefaultColor);
 
+    public IReadOnlyList<string> SharedTags { get; set; }
+
     /// <summary>
     /// Load the current configuration.
     /// Includes adding new colors and migrating from old versions.

--- a/Penumbra/Configuration.cs
+++ b/Penumbra/Configuration.cs
@@ -87,8 +87,6 @@ public class Configuration : IPluginConfiguration, ISavable
     public Dictionary<ColorId, uint> Colors { get; set; }
         = Enum.GetValues<ColorId>().ToDictionary(c => c, c => c.Data().DefaultColor);
 
-    public IReadOnlyList<string> SharedTags { get; set; }
-
     /// <summary>
     /// Load the current configuration.
     /// Includes adding new colors and migrating from old versions.

--- a/Penumbra/Services/FilenameService.cs
+++ b/Penumbra/Services/FilenameService.cs
@@ -14,6 +14,7 @@ public class FilenameService(DalamudPluginInterface pi) : IService
     public readonly string EphemeralConfigFile   = Path.Combine(pi.ConfigDirectory.FullName, "ephemeral_config.json");
     public readonly string FilesystemFile        = Path.Combine(pi.ConfigDirectory.FullName, "sort_order.json");
     public readonly string ActiveCollectionsFile = Path.Combine(pi.ConfigDirectory.FullName, "active_collections.json");
+    public readonly string SharedTagFile         = Path.Combine(pi.ConfigDirectory.FullName, "shared_tags.json");
 
     /// <summary> Obtain the path of a collection file given its name.</summary>
     public string CollectionFile(ModCollection collection)

--- a/Penumbra/Services/ServiceManagerA.cs
+++ b/Penumbra/Services/ServiceManagerA.cs
@@ -103,7 +103,8 @@ public static class ServiceManagerA
 
     private static ServiceManager AddConfiguration(this ServiceManager services)
         => services.AddSingleton<Configuration>()
-            .AddSingleton<EphemeralConfig>();
+            .AddSingleton<EphemeralConfig>()
+            .AddSingleton<SharedTagManager>();
 
     private static ServiceManager AddCollections(this ServiceManager services)
         => services.AddSingleton<CollectionStorage>()

--- a/Penumbra/UI/Classes/Colors.cs
+++ b/Penumbra/UI/Classes/Colors.cs
@@ -28,6 +28,8 @@ public enum ColorId
     ResTreePlayer,
     ResTreeNetworked,
     ResTreeNonNetworked,
+    SharedTagAdd,
+    SharedTagRemove
 }
 
 public static class Colors
@@ -73,6 +75,8 @@ public static class Colors
             ColorId.ResTreePlayer        => ( 0xFFC0FFC0, "On-Screen: Other Players",            "Other players and what they own, in the On-Screen tab." ),
             ColorId.ResTreeNetworked     => ( 0xFFFFFFFF, "On-Screen: Non-Players (Networked)",  "Non-player entities handled by the game server, in the On-Screen tab." ),
             ColorId.ResTreeNonNetworked  => ( 0xFFC0C0FF, "On-Screen: Non-Players (Local)",      "Non-player entities handled locally, in the On-Screen tab." ),
+            ColorId.SharedTagAdd         => ( 0xFF44AA44, "Shared Tags: Add Tag",                "A shared tag that is not present on the current mod and can be added." ),
+            ColorId.SharedTagRemove      => ( 0xFF2222AA, "Shared Tags: Remove Tag",             "A shared tag that is already present on the current mod and can be removed." ),
             _                            => throw new ArgumentOutOfRangeException( nameof( color ), color, null ),
             // @formatter:on
         };

--- a/Penumbra/UI/ModsTab/ModPanelDescriptionTab.cs
+++ b/Penumbra/UI/ModsTab/ModPanelDescriptionTab.cs
@@ -36,7 +36,7 @@ public class ModPanelDescriptionTab : ITab
         ImGui.Dummy(ImGuiHelpers.ScaledVector2(2));
 
         ImGui.Dummy(ImGuiHelpers.ScaledVector2(2));
-        var sharedTagsEnabled = _sharedTagManager.SharedTags.Count() > 0;
+        var sharedTagsEnabled = _sharedTagManager.SharedTags.Count > 0;
         var sharedTagButtonOffset = sharedTagsEnabled ? ImGui.GetFrameHeight() + ImGui.GetStyle().FramePadding.X : 0;
         var tagIdx = _localTags.Draw("Local Tags: ",
             "Custom tags you can set personally that will not be exported to the mod data but only set for you.\n"
@@ -48,23 +48,7 @@ public class ModPanelDescriptionTab : ITab
 
         if (sharedTagsEnabled)
         {
-            ImGui.SetCursorPosY(ImGui.GetCursorPosY() - ImGui.GetFrameHeightWithSpacing());
-            ImGui.SetCursorPosX(ImGui.GetWindowWidth() - ImGui.GetFrameHeight() - ImGui.GetStyle().FramePadding.X);
-            var sharedTag = _sharedTagManager.DrawAddFromSharedTags(_selector.Selected!.LocalTags, _selector.Selected!.ModTags, true);
-            if (sharedTag.Length > 0)
-            {
-                var index = _selector.Selected!.LocalTags.IndexOf(sharedTag);
-                if (index < 0)
-                {
-                    index = _selector.Selected!.LocalTags.Count;
-                    _modManager.DataEditor.ChangeLocalTag(_selector.Selected, index, sharedTag);
-                }
-                else
-                {
-                    _modManager.DataEditor.ChangeLocalTag(_selector.Selected, index, string.Empty);
-                }
-
-            }
+            _sharedTagManager.DrawAddFromSharedTagsAndUpdateTags(_selector.Selected!.LocalTags, _selector.Selected!.ModTags, true, _selector.Selected!);
         }
 
         if (_selector.Selected!.ModTags.Count > 0)

--- a/Penumbra/UI/ModsTab/ModPanelDescriptionTab.cs
+++ b/Penumbra/UI/ModsTab/ModPanelDescriptionTab.cs
@@ -12,14 +12,16 @@ public class ModPanelDescriptionTab : ITab
     private readonly ModFileSystemSelector _selector;
     private readonly TutorialService       _tutorial;
     private readonly ModManager            _modManager;
+    private readonly SharedTagManager      _sharedTagManager;
     private readonly TagButtons            _localTags = new();
     private readonly TagButtons            _modTags   = new();
 
-    public ModPanelDescriptionTab(ModFileSystemSelector selector, TutorialService tutorial, ModManager modManager)
+    public ModPanelDescriptionTab(ModFileSystemSelector selector, TutorialService tutorial, ModManager modManager, SharedTagManager sharedTagsConfig)
     {
         _selector   = selector;
         _tutorial   = tutorial;
         _modManager = modManager;
+        _sharedTagManager = sharedTagsConfig;
     }
 
     public ReadOnlySpan<byte> Label
@@ -34,13 +36,36 @@ public class ModPanelDescriptionTab : ITab
         ImGui.Dummy(ImGuiHelpers.ScaledVector2(2));
 
         ImGui.Dummy(ImGuiHelpers.ScaledVector2(2));
+        var sharedTagsEnabled = _sharedTagManager.SharedTags.Count() > 0;
+        var sharedTagButtonOffset = sharedTagsEnabled ? ImGui.GetFrameHeight() + ImGui.GetStyle().FramePadding.X : 0;
         var tagIdx = _localTags.Draw("Local Tags: ",
             "Custom tags you can set personally that will not be exported to the mod data but only set for you.\n"
           + "If the mod already contains a local tag in its own tags, the local tag will be ignored.", _selector.Selected!.LocalTags,
-            out var editedTag);
+            out var editedTag, rightEndOffset: sharedTagButtonOffset);
         _tutorial.OpenTutorial(BasicTutorialSteps.Tags);
         if (tagIdx >= 0)
             _modManager.DataEditor.ChangeLocalTag(_selector.Selected!, tagIdx, editedTag);
+
+        if (sharedTagsEnabled)
+        {
+            ImGui.SetCursorPosY(ImGui.GetCursorPosY() - ImGui.GetFrameHeightWithSpacing());
+            ImGui.SetCursorPosX(ImGui.GetWindowWidth() - ImGui.GetFrameHeight() - ImGui.GetStyle().FramePadding.X);
+            var sharedTag = _sharedTagManager.DrawAddFromSharedTags(_selector.Selected!.LocalTags, _selector.Selected!.ModTags, true);
+            if (sharedTag.Length > 0)
+            {
+                var index = _selector.Selected!.LocalTags.IndexOf(sharedTag);
+                if (index < 0)
+                {
+                    index = _selector.Selected!.LocalTags.Count;
+                    _modManager.DataEditor.ChangeLocalTag(_selector.Selected, index, sharedTag);
+                }
+                else
+                {
+                    _modManager.DataEditor.ChangeLocalTag(_selector.Selected, index, string.Empty);
+                }
+
+            }
+        }
 
         if (_selector.Selected!.ModTags.Count > 0)
             _modTags.Draw("Mod Tags: ", "Tags assigned by the mod creator and saved with the mod data. To edit these, look at Edit Mod.",

--- a/Penumbra/UI/ModsTab/ModPanelEditTab.cs
+++ b/Penumbra/UI/ModsTab/ModPanelEditTab.cs
@@ -83,7 +83,7 @@ public class ModPanelEditTab : ITab
             }
 
         UiHelpers.DefaultLineSpace();
-        var sharedTagsEnabled = _sharedTagManager.SharedTags.Count() > 0;
+        var sharedTagsEnabled = _sharedTagManager.SharedTags.Count > 0;
         var sharedTagButtonOffset = sharedTagsEnabled ? ImGui.GetFrameHeight() + ImGui.GetStyle().FramePadding.X : 0;
         var tagIdx = _modTags.Draw("Mod Tags: ", "Edit tags by clicking them, or add new tags. Empty tags are removed.", _mod.ModTags,
             out var editedTag, rightEndOffset: sharedTagButtonOffset);
@@ -92,23 +92,7 @@ public class ModPanelEditTab : ITab
 
         if (sharedTagsEnabled)
         {
-            ImGui.SetCursorPosY(ImGui.GetCursorPosY() - ImGui.GetFrameHeightWithSpacing());
-            ImGui.SetCursorPosX(ImGui.GetWindowWidth() - ImGui.GetFrameHeight() - ImGui.GetStyle().FramePadding.X);
-            var sharedTag = _sharedTagManager.DrawAddFromSharedTags(_selector.Selected!.LocalTags, _selector.Selected!.ModTags, false);
-            if (sharedTag.Length > 0)
-            {
-                var index = _selector.Selected!.ModTags.IndexOf(sharedTag);
-                if (index < 0)
-                {
-                    index = _selector.Selected!.ModTags.Count;
-                    _modManager.DataEditor.ChangeModTag(_selector.Selected, index, sharedTag);
-                }
-                else
-                {
-                    _modManager.DataEditor.ChangeModTag(_selector.Selected, index, string.Empty);
-                }
-
-            }
+            _sharedTagManager.DrawAddFromSharedTagsAndUpdateTags(_selector.Selected!.LocalTags, _selector.Selected!.ModTags, false, _selector.Selected!);
         }
 
         UiHelpers.DefaultLineSpace();

--- a/Penumbra/UI/SharedTagManager.cs
+++ b/Penumbra/UI/SharedTagManager.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dalamud.Interface;
+using ImGuiNET;
+using OtterGui;
+using OtterGui.Raii;
+using OtterGui.Widgets;
+using Penumbra.Mods;
+using Penumbra.UI.Classes;
+
+namespace Penumbra.UI;
+public sealed class SharedTagManager
+{
+    private static uint _tagButtonAddColor = ColorId.SharedTagAdd.Value();
+    private static uint _tagButtonRemoveColor = ColorId.SharedTagRemove.Value();
+
+    private static float _minTagButtonWidth = 15;
+
+    private const string PopupContext = "SharedTagsPopup";
+    private bool _isPopupOpen = false;
+
+
+    public IReadOnlyList<string> SharedTags { get; internal set; } = Array.Empty<string>();
+
+    public SharedTagManager()
+    {
+    }
+
+    public void ChangeSharedTag(int tagIdx, string tag)
+    {
+        if (tagIdx < 0 || tagIdx > SharedTags.Count)
+            return;
+
+        if (tagIdx == SharedTags.Count) // Adding a new tag
+        {
+            SharedTags = SharedTags.Append(tag).Distinct().Where(tag => tag.Length > 0).OrderBy(a => a).ToArray();
+        }
+        else // Editing an existing tag
+        {
+            var tmpTags = SharedTags.ToArray();
+            tmpTags[tagIdx] = tag;
+            SharedTags = tmpTags.Distinct().Where(tag => tag.Length > 0).OrderBy(a => a).ToArray();
+        }
+    }
+
+    public string DrawAddFromSharedTags(IReadOnlyCollection<string> localTags, IReadOnlyCollection<string> modTags, bool editLocal)
+    {
+        var tagToAdd = "";
+        if (ImGuiUtil.DrawDisabledButton(FontAwesomeIcon.Tags.ToIconString(), new Vector2(ImGui.GetFrameHeight()), "Add Shared Tag... (Right-click to close popup)",
+            false, true) || _isPopupOpen)
+            return DrawSharedTagsPopup(localTags, modTags, editLocal);
+
+
+        return tagToAdd;
+    }
+
+    private string DrawSharedTagsPopup(IReadOnlyCollection<string> localTags, IReadOnlyCollection<string> modTags, bool editLocal)
+    {
+        var selected = "";
+        if (!ImGui.IsPopupOpen(PopupContext))
+        {
+            ImGui.OpenPopup(PopupContext);
+            _isPopupOpen = true;
+        }
+
+        var display = ImGui.GetIO().DisplaySize;
+        var height = Math.Min(display.Y / 4, 10 * ImGui.GetFrameHeightWithSpacing());
+        var width = display.X / 6;
+        var size = new Vector2(width, height);
+        ImGui.SetNextWindowSize(size);
+        using var popup = ImRaii.Popup(PopupContext);
+        if (!popup)
+            return selected;
+
+        ImGui.Text("Shared Tags");
+        ImGuiUtil.HoverTooltip("Right-click to close popup");
+        ImGui.Separator();
+
+        foreach (var tag in SharedTags)
+        {
+            if (DrawColoredButton(localTags, modTags, tag, editLocal))
+            {
+                selected = tag;
+                return selected;
+            }
+            ImGui.SameLine();
+        }
+
+        if (ImGui.IsMouseClicked(ImGuiMouseButton.Right))
+        {
+            _isPopupOpen = false;
+        }
+
+        return selected;
+    }
+
+    private static bool DrawColoredButton(IReadOnlyCollection<string> localTags, IReadOnlyCollection<string> modTags, string buttonLabel, bool editLocal)
+    {
+        var isLocalTagPresent = localTags.Contains(buttonLabel);
+        var isModTagPresent = modTags.Contains(buttonLabel);
+
+        var buttonWidth = CalcTextButtonWidth(buttonLabel);
+        // Would prefer to be able to fit at least 2 buttons per line so the popup doesn't look sparse with lots of long tags. Thus long tags will be trimmed.
+        var maxButtonWidth = (ImGui.GetContentRegionMax().X - ImGui.GetWindowContentRegionMin().X) * 0.5f - ImGui.GetStyle().ItemSpacing.X;
+        var displayedLabel = buttonLabel;
+        if (buttonWidth >= maxButtonWidth)
+        {
+            displayedLabel = TrimButtonTextToWidth(buttonLabel, maxButtonWidth);
+            buttonWidth = CalcTextButtonWidth(displayedLabel);
+        }
+
+        // Prevent adding a new tag past the right edge of the popup
+        if (buttonWidth + ImGui.GetStyle().ItemSpacing.X >= ImGui.GetContentRegionAvail().X)
+            ImGui.NewLine();
+
+        // Trimmed tag names can collide, but the full tags are guaranteed distinct so use the full tag as the ID to avoid an ImGui moment.
+        ImRaii.PushId(buttonLabel);
+
+        if (editLocal && isModTagPresent || !editLocal && isLocalTagPresent)
+        {
+            using var alpha = ImRaii.PushStyle(ImGuiStyleVar.Alpha, 0.5f);
+            ImGui.Button(displayedLabel);
+            alpha.Pop();
+            return false;
+        }
+
+        using (ImRaii.PushColor(ImGuiCol.Button, isLocalTagPresent || isModTagPresent ? _tagButtonRemoveColor : _tagButtonAddColor))
+        {
+            return ImGui.Button(displayedLabel);
+        }
+    }
+
+    private static string TrimButtonTextToWidth(string fullText, float maxWidth)
+    {
+        var trimmedText = fullText;
+
+        while (trimmedText.Length > _minTagButtonWidth)
+        {
+            var nextTrim = trimmedText.Substring(0, Math.Max(trimmedText.Length - 1, 0));
+
+            // An ellipsis will be used to indicate trimmed tags
+            if (CalcTextButtonWidth(nextTrim + "...") < maxWidth)
+            {
+                return nextTrim + "...";
+            }
+            trimmedText = nextTrim;
+        }
+
+        return trimmedText;
+    }
+
+    private static float CalcTextButtonWidth(string text)
+    {
+        return ImGui.CalcTextSize(text).X + 2 * ImGui.GetStyle().FramePadding.X;
+    }
+
+}

--- a/Penumbra/UI/Tabs/SettingsTab.cs
+++ b/Penumbra/UI/Tabs/SettingsTab.cs
@@ -73,8 +73,6 @@ public class SettingsTab : ITab
         if (_compactor.CanCompact)
             _compactor.Enabled = _config.UseFileSystemCompression;
         _sharedTagManager = sharedTagConfig;
-        if (sharedTagConfig.SharedTags.Count == 0 && _config.SharedTags != null)
-            sharedTagConfig.SharedTags = _config.SharedTags;
     }
 
     public void DrawHeader()
@@ -916,14 +914,12 @@ public class SettingsTab : ITab
             return;
 
         var tagIdx = _sharedTags.Draw("Shared Tags: ",
-            "Tags that can be added/removed from mods with 1 click.", _sharedTagManager.SharedTags,
+            "Predefined tags that can be added or removed from mods with a single click.", _sharedTagManager.SharedTags,
             out var editedTag);
 
         if (tagIdx >= 0)
         {
             _sharedTagManager.ChangeSharedTag(tagIdx, editedTag);
-            _config.SharedTags = _sharedTagManager.SharedTags;
-            _config.Save();
         }
     }
 }


### PR DESCRIPTION
## Foreword
While coding is what I do for a living, I had absolutely zero experience with FFXIV plugin code or ImGui prior to this little project. As such I'm expecting there to be more than a few issues with this PR, and have marked it as a draft.

## Description

Adds a new system of shared tags that are saved in the Penumbra config, and can then be 1-click added or removed to/from mods via a popup menu. The use case for this new system is to allow users to more easily re-use tags and to allow them to quickly tag individual mods.

Shared tags can be added/removed/modified via a new Tags section of the main Penumbra Settings tab. Once any shared tags have been saved, the menu to add a shared tag to a mod can be accessed via a new tags button that shows up in the Description and Edit Mod tabs, to the right of the existing + button that already existed for typing in new tags.

Clicking the new button will open a popup that is populated with buttons for each shared tag that the user has saved. Tags that can be added are indicated by green buttons, tags that can be removed by red. Tags that cannot be changed are grayed out, which happens if a user is editing local tags and a specific shared tag is already present as a mod tag (and vice versa). The popup will stay open until the user closes it with a right-click.

Shared tags have the same restrictions as regular mod tags, and the application of shared tags should respect the same limits as application of normal tags.

## Dependencies
~~I wasn't able to get the new button to align well with the existing elements without a change to TagButtons.cs. As a result, this PR is dependent on the [Ottermandias/OtterGui#9](https://github.com/Ottermandias/OtterGui/pull/9). Once that PR is merged in I can update this PR to point at the latest submodule commit.~~ The dependency has been merged in, and I have added a commit to update the OtterGui version in the PR.

In order to avoid changing too much of the logic there, I simply added an optional parameter that allows offsetting how far from the right edge of the window that the + button can be drawn.

## Issues
The screenshot link in the issue is dead, but I think this likely fulfills #307.

## Screenshots
### Settings
![Settings Tab](https://github.com/xivdev/Penumbra/assets/146025884/9caec281-16d6-454f-9b9d-fb61aa284780)
### Mod Description
![Mod Description Tab](https://github.com/xivdev/Penumbra/assets/146025884/a609b796-8d4b-4908-99c4-85478698425e)
### Edit Mod
![Mod Edit Mod Tab](https://github.com/xivdev/Penumbra/assets/146025884/35b40ac6-e836-4756-9317-11abb4d61731)
### Mod Description with Shared Tags Popup
![Mods Description Tab with Popup](https://github.com/xivdev/Penumbra/assets/146025884/8be241ce-a466-490b-881d-5e654f215a84)
### Mod Description with Shared Tags Popup 2
![Mods Description Tab with Popup 2](https://github.com/xivdev/Penumbra/assets/146025884/5dd35018-0ef1-4866-a6e5-8fbe1ddce2ef)
* Ignore the fact that the popup says "Saved Tags" instead of "Shared Tags". I noticed that and fixed it just before publishing this PR and didn't want to re-take the screenshots.