### PR TITLE
Add triangle count per LoD to models tab

### DIFF
--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -508,6 +508,11 @@ public partial class ModEditWindow
                 ImGuiUtil.DrawTableColumn(file.VertexDeclarations.Length.ToString());
                 ImGuiUtil.DrawTableColumn("Stack Size");
                 ImGuiUtil.DrawTableColumn(file.StackSize.ToString());
+                for (var lod = 0; lod < file.Lods.Length; lod++)
+                {
+                    ImGuiUtil.DrawTableColumn("LoD " + lod + " Triangle Count");
+                    ImGuiUtil.DrawTableColumn(GetTriangleCountForLod(file, lod).ToString());
+                }
             }
         }
 
@@ -553,6 +558,18 @@ public partial class ModEditWindow
     {
         file = files.FirstOrDefault(f => ValidModelExtensions.Contains(Path.GetExtension(f).ToLowerInvariant()));
         return file != null;
+    }
+
+    private static long GetTriangleCountForLod(MdlFile model, int lod)
+    {
+        var vertSum = 0u;
+        var meshIndex = model.Lods[lod].MeshIndex;
+        var meshCount = model.Lods[lod].MeshCount;
+
+        for (var i = meshIndex; i < meshIndex + meshCount; i++)
+            vertSum += model.Meshes[i].IndexCount;
+
+        return vertSum / 3;
     }
 
     private static readonly string[] ValidModelExtensions =


### PR DESCRIPTION
Adds the tri count of each LoD on the selected model in the Models tab under Advanced Editing. This information is mostly there for advanced users who may want to know how resource heavy a model is without having to export to .gtlf file and open it in Blender.

I figured it was worth displaying the info for each LoD, given that at some point Penumbra model import may support LoDs.

---
Example on the vanilla Makai Harrower/Manhandler Jerkin:

![A screenshot of the Penumbra Models tab that contains three newly added rows indicating the number of triangles in the model LoDs 0 to 2 for the Makai Manhandler Jerkin. LoD 0 has 2720 triangles, LoD 1 has 1298 triangles, and LoD 2 has 519 triangles.](https://github.com/xivdev/Penumbra/assets/146025884/f0094cf7-9f28-4029-8c63-a1bc701a953e)
