### PR TITLE
Multiple tags and search options

### DIFF
--- a/Penumbra/UI/ModsTab/ModFileSystemSelector.cs
+++ b/Penumbra/UI/ModsTab/ModFileSystemSelector.cs
@@ -569,8 +569,6 @@ public sealed class ModFileSystemSelector : FileSystemSelector<Mod, ModFileSyste
     }
 
     private const StringComparison                  IgnoreCase   = StringComparison.OrdinalIgnoreCase;
-    //private       LowerString                       _modFilter   = LowerString.Empty;
-    //private       int                               _filterType  = -1;
     private       List<(LowerString, int)>          _modFilters = new System.Collections.Generic.List<(LowerString, int)>();
     private       ModFilter                         _stateFilter = ModFilterExtensions.UnfilteredStateMods;
     private       ChangedItemDrawer.ChangedItemIcon _slotFilter  = 0;


### PR DESCRIPTION
Here's a (hopefully reasonable) attempt at allowing for a more complicated search on the mods. Wrote up a regex function to break into blocks(individual words work as separate search filters, and quotes ('"`) will group search terms together alone or after a tag). 

**multi term**
will show all mods containing 'multi' and 'term'

**'multi term'**
will search the string 'multi term'(without quotes)

**t:multi term**
will return anything with a tag containing multi, and containing 'term'

**t:'multi term'**
will only return mods with tags containing 'multi term'