### PR TITLE
Init support for DT model i/o

### DIFF
--- a/Penumbra/Import/Models/Export/MaterialExporter.cs
+++ b/Penumbra/Import/Models/Export/MaterialExporter.cs
@@ -340,21 +340,7 @@ public class MaterialExporter
         var diffuse = material.Textures[TextureUsage.SamplerDiffuse];
         var normal  = material.Textures[TextureUsage.SamplerNormal];
 
-        // Create a copy of the normal that's the same size as the diffuse for purposes of copying the opacity across.
-        var resizedNormal = normal.Clone(context => context.Resize(diffuse.Width, diffuse.Height));
-        diffuse.ProcessPixelRows(resizedNormal, (diffuseAccessor, normalAccessor) =>
-        {
-            for (var y = 0; y < diffuseAccessor.Height; y++)
-            {
-                var diffuseSpan = diffuseAccessor.GetRowSpan(y);
-                var normalSpan  = normalAccessor.GetRowSpan(y);
-
-                for (var x = 0; x < diffuseSpan.Length; x++)
-                    diffuseSpan[x].A = normalSpan[x].B;
-            }
-        });
-
-        // Clear the blue channel out of the normal now that we're done with it.
+        // The normal also stores the skin color influence (.b) and wetness mask (.a) - remove.
         normal.ProcessPixelRows(normalAccessor =>
         {
             for (var y = 0; y < normalAccessor.Height; y++)
@@ -362,7 +348,10 @@ public class MaterialExporter
                 var normalSpan = normalAccessor.GetRowSpan(y);
 
                 for (var x = 0; x < normalSpan.Length; x++)
+                {
                     normalSpan[x].B = byte.MaxValue;
+                    normalSpan[x].A = byte.MaxValue;
+                }
             }
         });
 

--- a/Penumbra/Import/Models/Export/MaterialExporter.cs
+++ b/Penumbra/Import/Models/Export/MaterialExporter.cs
@@ -306,10 +306,11 @@ public class MaterialExporter
 
                 for (var x = 0; x < normalSpan.Length; x++)
                 {
-                    var color = Vector4.Lerp(DefaultHairColor, DefaultHighlightColor, maskSpan[x].A / 255f);
-                    baseColorSpan[x].FromVector4(color * new Vector4(maskSpan[x].R / 255f));
+                    var color = Vector4.Lerp(DefaultHairColor, DefaultHighlightColor, normalSpan[x].B / 255f);
+                    baseColorSpan[x].FromVector4(color * new Vector4(maskSpan[x].A / 255f));
                     baseColorSpan[x].A = normalSpan[x].A;
 
+                    normalSpan[x].B = byte.MaxValue;
                     normalSpan[x].A = byte.MaxValue;
                 }
             }

--- a/Penumbra/Import/Models/Export/MaterialExporter.cs
+++ b/Penumbra/Import/Models/Export/MaterialExporter.cs
@@ -36,12 +36,13 @@ public class MaterialExporter
         return material.Mtrl.ShaderPackage.Name switch
         {
             // NOTE: this isn't particularly precise to game behavior (it has some fade around high opacity), but good enough for now.
-            "character.shpk"      => BuildCharacter(material, name).WithAlpha(AlphaMode.MASK, 0.5f),
-            "characterglass.shpk" => BuildCharacter(material, name).WithAlpha(AlphaMode.BLEND),
-            "hair.shpk"           => BuildHair(material, name),
-            "iris.shpk"           => BuildIris(material, name),
-            "skin.shpk"           => BuildSkin(material, name),
-            _                     => BuildFallback(material, name, notifier),
+            "character.shpk"       => BuildCharacter(material, name).WithAlpha(AlphaMode.MASK, 0.5f),
+            "characterlegacy.shpk" => BuildCharacter(material, name).WithAlpha(AlphaMode.MASK, 0.5f),
+            "characterglass.shpk"  => BuildCharacter(material, name).WithAlpha(AlphaMode.BLEND),
+            "hair.shpk"            => BuildHair(material, name),
+            "iris.shpk"            => BuildIris(material, name),
+            "skin.shpk"            => BuildSkin(material, name),
+            _                      => BuildFallback(material, name, notifier),
         };
     }
 
@@ -49,70 +50,65 @@ public class MaterialExporter
     private static MaterialBuilder BuildCharacter(Material material, string name)
     {
         // Build the textures from the color table.
-        var table = new LegacyColorTable(material.Mtrl.Table!);
+        var table = new ColorTable(material.Mtrl.Table!);
+        var indexTexture = material.Textures[(TextureUsage)1449103320];
+        var indexOperation = new ProcessCharacterIndexOperation(indexTexture, table);
+        ParallelRowIterator.IterateRows(ImageSharpConfiguration.Default, indexTexture.Bounds, in indexOperation);
 
-        var normal = material.Textures[TextureUsage.SamplerNormal];
+        var normalTexture = material.Textures[TextureUsage.SamplerNormal];
+        var normalOperation = new ProcessCharacterNormalOperation(normalTexture);
+        ParallelRowIterator.IterateRows(ImageSharpConfiguration.Default, normalTexture.Bounds, in normalOperation);
 
-        var operation = new ProcessCharacterNormalOperation(normal, table);
-        ParallelRowIterator.IterateRows(ImageSharpConfiguration.Default, normal.Bounds, in operation);
+        // Merge in opacity from the normal.
+        var baseColor = indexOperation.BaseColor;
+        MultiplyOperation.Execute(baseColor, normalOperation.BaseColorOpacity);
 
-        // Check if full textures are provided, and merge in if available.
-        var baseColor = operation.BaseColor;
+        // Check if a full diffuse is provided, and merge in if available.
         if (material.Textures.TryGetValue(TextureUsage.SamplerDiffuse, out var diffuse))
         {
-            MultiplyOperation.Execute(diffuse, operation.BaseColor);
+            MultiplyOperation.Execute(diffuse, indexOperation.BaseColor);
             baseColor = diffuse;
         }
 
-        Image specular = operation.Specular;
+        var specular = indexOperation.Specular;
         if (material.Textures.TryGetValue(TextureUsage.SamplerSpecular, out var specularTexture))
         {
-            MultiplyOperation.Execute(specularTexture, operation.Specular);
+            MultiplyOperation.Execute(specularTexture, indexOperation.Specular);
             specular = specularTexture;
         }
 
         // Pull further information from the mask.
         if (material.Textures.TryGetValue(TextureUsage.SamplerMask, out var maskTexture))
         {
-            // Extract the red channel for "ambient occlusion".
-            maskTexture.Mutate(context => context.Resize(baseColor.Width, baseColor.Height));
-            maskTexture.ProcessPixelRows(baseColor, (maskAccessor, baseColorAccessor) =>
-            {
-                for (var y = 0; y < maskAccessor.Height; y++)
-                {
-                    var maskSpan      = maskAccessor.GetRowSpan(y);
-                    var baseColorSpan = baseColorAccessor.GetRowSpan(y);
+            var maskOperation = new ProcessCharacterMaskOperation(maskTexture);
+            ParallelRowIterator.IterateRows(ImageSharpConfiguration.Default, maskTexture.Bounds, in maskOperation);
 
-                    for (var x = 0; x < maskSpan.Length; x++)
-                        baseColorSpan[x].FromVector4(baseColorSpan[x].ToVector4() * new Vector4(maskSpan[x].R / 255f));
-                }
-            });
-            // TODO: handle other textures stored in the mask?
+            // TODO: consider using the occusion gltf material property.
+            MultiplyOperation.Execute(baseColor, maskOperation.Occlusion);
+
+            // Similar to base color's alpha, this is a pretty wasteful operation for a single channel.
+            MultiplyOperation.Execute(specular, maskOperation.SpecularFactor);
         }
 
         // Specular extension puts colour on RGB and factor on A. We're already packing like that, so we can reuse the texture.
         var specularImage = BuildImage(specular, name, "specular");
 
         return BuildSharedBase(material, name)
-            .WithBaseColor(BuildImage(baseColor,         name, "basecolor"))
-            .WithNormal(BuildImage(operation.Normal,     name, "normal"))
-            .WithEmissive(BuildImage(operation.Emissive, name, "emissive"), Vector3.One, 1)
+            .WithBaseColor(BuildImage(baseColor,              name, "basecolor"))
+            .WithNormal(BuildImage(normalOperation.Normal,    name, "normal"))
+            .WithEmissive(BuildImage(indexOperation.Emissive, name, "emissive"), Vector3.One, 1)
             .WithSpecularFactor(specularImage, 1)
             .WithSpecularColor(specularImage);
     }
 
-    // TODO: It feels a little silly to request the entire normal here when extracting the normal only needs some of the components.
-    //       As a future refactor, it would be neat to accept a single-channel field here, and then do composition of other stuff later.
-    // TODO(Dawntrail): Use the dedicated index (_id) map, that is not embedded in the normal map's alpha channel anymore.
-    private readonly struct ProcessCharacterNormalOperation(Image<Rgba32> normal, LegacyColorTable table) : IRowOperation
+    private readonly struct ProcessCharacterIndexOperation(Image<Rgba32> index, ColorTable table) : IRowOperation
     {
-        public Image<Rgba32> Normal    { get; } = normal.Clone();
-        public Image<Rgba32> BaseColor { get; } = new(normal.Width, normal.Height);
-        public Image<Rgba32> Specular  { get; } = new(normal.Width, normal.Height);
-        public Image<Rgb24>  Emissive  { get; } = new(normal.Width, normal.Height);
+        public Image<Rgba32> BaseColor { get; } = new(index.Width, index.Height);
+        public Image<Rgba32> Specular  { get; } = new(index.Width, index.Height);
+        public Image<Rgb24>  Emissive  { get; } = new(index.Width, index.Height);
 
-        private Buffer2D<Rgba32> NormalBuffer
-            => Normal.Frames.RootFrame.PixelBuffer;
+        private Buffer2D<Rgba32> IndexBuffer
+            => index.Frames.RootFrame.PixelBuffer;
 
         private Buffer2D<Rgba32> BaseColorBuffer
             => BaseColor.Frames.RootFrame.PixelBuffer;
@@ -125,66 +121,96 @@ public class MaterialExporter
 
         public void Invoke(int y)
         {
-            var normalSpan    = NormalBuffer.DangerousGetRowSpan(y);
+            var indexSpan = IndexBuffer.DangerousGetRowSpan(y);
             var baseColorSpan = BaseColorBuffer.DangerousGetRowSpan(y);
             var specularSpan  = SpecularBuffer.DangerousGetRowSpan(y);
             var emissiveSpan  = EmissiveBuffer.DangerousGetRowSpan(y);
+
+            for (var x = 0; x < indexSpan.Length; x++)
+            {
+                ref var indexPixel = ref indexSpan[x];
+
+                // Calculate and fetch the color table rows being used for this pixel.
+                var tablePair = (int) Math.Round(indexPixel.R / 17f);
+                var rowBlend = 1.0f - indexPixel.G / 255f;
+
+                var prevRow = table[tablePair * 2];
+                var nextRow = table[Math.Min(tablePair * 2 + 1, ColorTable.NumRows)];
+
+                // Lerp between table row values to fetch final pixel values for each subtexture.
+                var lerpedDiffuse = Vector3.Lerp((Vector3)prevRow.DiffuseColor, (Vector3)nextRow.DiffuseColor, rowBlend);
+                baseColorSpan[x].FromVector4(new Vector4(lerpedDiffuse, 1));
+
+                var lerpedSpecularColor = Vector3.Lerp((Vector3)prevRow.SpecularColor, (Vector3)nextRow.SpecularColor, rowBlend);
+                specularSpan[x].FromVector4(new Vector4(lerpedSpecularColor, 1));
+
+                var lerpedEmissive = Vector3.Lerp((Vector3)prevRow.EmissiveColor, (Vector3)nextRow.EmissiveColor, rowBlend);
+                emissiveSpan[x].FromVector4(new Vector4(lerpedEmissive, 1));
+            }
+        }
+    }
+    
+    private readonly struct ProcessCharacterNormalOperation(Image<Rgba32> normal) : IRowOperation
+    {
+        // TODO: Consider omitting the alpha channel here.
+        public Image<Rgba32> Normal { get; } = normal.Clone();
+        // TODO: We only really need the alpha here, however using A8 will result in the multiply later zeroing out the RGB channels.
+        public Image<Rgba32> BaseColorOpacity { get; } = new(normal.Width, normal.Height);
+
+        private Buffer2D<Rgba32> NormalBuffer
+            => Normal.Frames.RootFrame.PixelBuffer;
+
+        private Buffer2D<Rgba32> BaseColorOpacityBuffer
+            => BaseColorOpacity.Frames.RootFrame.PixelBuffer;
+
+        public void Invoke(int y)
+        {
+            var normalSpan = NormalBuffer.DangerousGetRowSpan(y);
+            var baseColorOpacitySpan = BaseColorOpacityBuffer.DangerousGetRowSpan(y);
 
             for (var x = 0; x < normalSpan.Length; x++)
             {
                 ref var normalPixel = ref normalSpan[x];
 
-                // Table row data (.a)
-                var tableRow = GetTableRowIndices(normalPixel.A / 255f);
-                var prevRow  = table[tableRow.Previous];
-                var nextRow  = table[tableRow.Next];
+                baseColorOpacitySpan[x].FromVector4(Vector4.One);
+                baseColorOpacitySpan[x].A = normalPixel.B;
 
-                // Base colour (table, .b)
-                var lerpedDiffuse = Vector3.Lerp((Vector3)prevRow.DiffuseColor, (Vector3)nextRow.DiffuseColor, tableRow.Weight);
-                baseColorSpan[x].FromVector4(new Vector4(lerpedDiffuse, 1));
-                baseColorSpan[x].A = normalPixel.B;
-
-                // Specular (table)
-                var lerpedSpecularColor = Vector3.Lerp((Vector3)prevRow.SpecularColor, (Vector3)nextRow.SpecularColor, tableRow.Weight);
-                var lerpedSpecularFactor = float.Lerp((float)prevRow.SpecularMask, (float)nextRow.SpecularMask, tableRow.Weight);
-                specularSpan[x].FromVector4(new Vector4(lerpedSpecularColor, lerpedSpecularFactor));
-
-                // Emissive (table)
-                var lerpedEmissive = Vector3.Lerp((Vector3)prevRow.EmissiveColor, (Vector3)nextRow.EmissiveColor, tableRow.Weight);
-                emissiveSpan[x].FromVector4(new Vector4(lerpedEmissive, 1));
-
-                // Normal (.rg)
-                // TODO: we don't actually need alpha at all for normal, but _not_ using the existing rgba texture means I'll need a new one, with a new accessor. Think about it.
                 normalPixel.B = byte.MaxValue;
                 normalPixel.A = byte.MaxValue;
             }
         }
     }
 
-    private static TableRow GetTableRowIndices(float input)
+    private readonly struct ProcessCharacterMaskOperation(Image<Rgba32> mask) : IRowOperation
     {
-        // These calculations are ported from character.shpk.
-        var smoothed = MathF.Floor(input * 7.5f % 1.0f * 2)
-          * (-input * 15 + MathF.Floor(input * 15 + 0.5f))
-          + input * 15;
+        public Image<Rgba32> Occlusion { get; } = new(mask.Width, mask.Height);
+        public Image<Rgba32> SpecularFactor { get; } = new(mask.Width, mask.Height);
 
-        var stepped = MathF.Floor(smoothed + 0.5f);
+        private Buffer2D<Rgba32> MaskBuffer
+            => mask.Frames.RootFrame.PixelBuffer;
 
-        return new TableRow
+        private Buffer2D<Rgba32> OcclusionBuffer
+            => Occlusion.Frames.RootFrame.PixelBuffer;
+
+        private Buffer2D<Rgba32> SpecularFactorBuffer
+            => SpecularFactor.Frames.RootFrame.PixelBuffer;
+
+        public void Invoke(int y)
         {
-            Stepped  = (int)stepped,
-            Previous = (int)MathF.Floor(smoothed),
-            Next     = (int)MathF.Ceiling(smoothed),
-            Weight   = smoothed % 1,
-        };
-    }
+            var maskSpan = MaskBuffer.DangerousGetRowSpan(y);
+            var occlusionSpan = OcclusionBuffer.DangerousGetRowSpan(y);
+            var specularFactorSpan = SpecularFactorBuffer.DangerousGetRowSpan(y);
 
-    private ref struct TableRow
-    {
-        public int   Stepped;
-        public int   Previous;
-        public int   Next;
-        public float Weight;
+            for (var x = 0; x < maskSpan.Length; x++)
+            {
+                ref var maskPixel = ref maskSpan[x];
+
+                occlusionSpan[x].FromL8(new L8(maskPixel.B));
+                
+                specularFactorSpan[x].FromVector4(Vector4.One);
+                specularFactorSpan[x].A = maskPixel.R;
+            }
+        }
     }
 
     private readonly struct MultiplyOperation

--- a/Penumbra/Import/Models/Export/MeshExporter.cs
+++ b/Penumbra/Import/Models/Export/MeshExporter.cs
@@ -538,6 +538,7 @@ public class MeshExporter
         => data switch
         {
             byte[] value   => value.Select(x => x / 255f).ToArray(),
+            Vector4 v4     => new[] { v4.X, v4.Y, v4.Z, v4.W },
             _              => throw new ArgumentOutOfRangeException($"Invalid float[] input {data}"),
         };
 }

--- a/Penumbra/Import/Models/Export/MeshExporter.cs
+++ b/Penumbra/Import/Models/Export/MeshExporter.cs
@@ -315,24 +315,9 @@ public class MeshExporter
             MdlFile.VertexType.NByte4 => new Vector4(reader.ReadByte() / 255f, reader.ReadByte() / 255f, reader.ReadByte() / 255f, reader.ReadByte() / 255f),
             MdlFile.VertexType.Half2 => new Vector2((float)reader.ReadHalf(), (float)reader.ReadHalf()),
             MdlFile.VertexType.Half4 => new Vector4((float)reader.ReadHalf(), (float)reader.ReadHalf(), (float)reader.ReadHalf(), (float)reader.ReadHalf()),
-            MdlFile.VertexType.UShort4 => ReadUShort4(reader),
+            MdlFile.VertexType.UShort4 => reader.ReadBytes(8),
             var other => throw _notifier.Exception<ArgumentOutOfRangeException>($"Unhandled vertex type {other}"),
         };
-    }
-    
-    private byte[] ReadUShort4(BinaryReader reader)
-    {
-        var buffer = reader.ReadBytes(8);
-        var byteValues = new byte[8];
-        byteValues[0] = buffer[0];
-        byteValues[4] = buffer[1];
-        byteValues[1] = buffer[2];
-        byteValues[5] = buffer[3];
-        byteValues[2] = buffer[4];
-        byteValues[6] = buffer[5];
-        byteValues[3] = buffer[6];
-        byteValues[7] = buffer[7];
-        return byteValues;
     }
 
     /// <summary> Get the vertex geometry type for this mesh's vertex usages. </summary>

--- a/Penumbra/Import/Models/Export/MeshExporter.cs
+++ b/Penumbra/Import/Models/Export/MeshExporter.cs
@@ -312,14 +312,27 @@ public class MeshExporter
             MdlFile.VertexType.Single3 => new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle()),
             MdlFile.VertexType.Single4 => new Vector4(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle()),
             MdlFile.VertexType.UByte4  => reader.ReadBytes(4),
-            MdlFile.VertexType.NByte4 => new Vector4(reader.ReadByte() / 255f, reader.ReadByte() / 255f, reader.ReadByte() / 255f,
-                reader.ReadByte() / 255f),
+            MdlFile.VertexType.NByte4 => new Vector4(reader.ReadByte() / 255f, reader.ReadByte() / 255f, reader.ReadByte() / 255f, reader.ReadByte() / 255f),
             MdlFile.VertexType.Half2 => new Vector2((float)reader.ReadHalf(), (float)reader.ReadHalf()),
-            MdlFile.VertexType.Half4 => new Vector4((float)reader.ReadHalf(), (float)reader.ReadHalf(), (float)reader.ReadHalf(),
-                (float)reader.ReadHalf()),
-
+            MdlFile.VertexType.Half4 => new Vector4((float)reader.ReadHalf(), (float)reader.ReadHalf(), (float)reader.ReadHalf(), (float)reader.ReadHalf()),
+            MdlFile.VertexType.UShort4 => ReadUShort4(reader),
             var other => throw _notifier.Exception<ArgumentOutOfRangeException>($"Unhandled vertex type {other}"),
         };
+    }
+    
+    private byte[] ReadUShort4(BinaryReader reader)
+    {
+        var buffer = reader.ReadBytes(8);
+        var byteValues = new byte[8];
+        byteValues[0] = buffer[0];
+        byteValues[4] = buffer[1];
+        byteValues[1] = buffer[2];
+        byteValues[5] = buffer[3];
+        byteValues[2] = buffer[4];
+        byteValues[6] = buffer[5];
+        byteValues[3] = buffer[6];
+        byteValues[7] = buffer[7];
+        return byteValues;
     }
 
     /// <summary> Get the vertex geometry type for this mesh's vertex usages. </summary>
@@ -445,7 +458,16 @@ public class MeshExporter
     private static Type GetSkinningType(IReadOnlyDictionary<MdlFile.VertexUsage, MdlFile.VertexType> usages)
     {
         if (usages.ContainsKey(MdlFile.VertexUsage.BlendWeights) && usages.ContainsKey(MdlFile.VertexUsage.BlendIndices))
-            return typeof(VertexJoints4);
+        {
+            if (usages[MdlFile.VertexUsage.BlendWeights] == MdlFile.VertexType.UShort4)
+            {
+                return typeof(VertexJoints8);
+            }
+            else
+            {
+                return typeof(VertexJoints4);
+            }
+        }
 
         return typeof(VertexEmpty);
     }
@@ -456,15 +478,17 @@ public class MeshExporter
         if (_skinningType == typeof(VertexEmpty))
             return new VertexEmpty();
 
-        if (_skinningType == typeof(VertexJoints4))
+        if (_skinningType == typeof(VertexJoints4) || _skinningType == typeof(VertexJoints8))
         {
             if (_boneIndexMap == null)
                 throw _notifier.Exception("Tried to build skinned vertex but no bone mappings are available.");
 
-            var indices = ToByteArray(attributes[MdlFile.VertexUsage.BlendIndices]);
-            var weights = ToVector4(attributes[MdlFile.VertexUsage.BlendWeights]);
-
-            var bindings = Enumerable.Range(0, 4)
+            var indiciesData = attributes[MdlFile.VertexUsage.BlendIndices];
+            var weightsData  = attributes[MdlFile.VertexUsage.BlendWeights];
+            var indices      = ToByteArray(indiciesData);
+            var weights      = ToFloatArray(weightsData);
+            
+            var bindings = Enumerable.Range(0, indices.Length)
                 .Select(bindingIndex =>
                 {
                     // NOTE: I've not seen any files that throw this error that aren't completely broken.
@@ -475,7 +499,13 @@ public class MeshExporter
                     return (jointIndex, weights[bindingIndex]);
                 })
                 .ToArray();
-            return new VertexJoints4(bindings);
+            
+            return bindings.Length switch
+            {
+                4 => new VertexJoints4(bindings),
+                8 => new VertexJoints8(bindings),
+                _ => throw _notifier.Exception($"Invalid number of bone bindings {bindings.Length}.")
+            };
         }
 
         throw _notifier.Exception($"Unknown skinning type {_skinningType}");
@@ -518,4 +548,12 @@ public class MeshExporter
             byte[] value => value,
             _            => throw new ArgumentOutOfRangeException($"Invalid byte[] input {data}"),
         };
+    
+    private static float[] ToFloatArray(object data)
+        => data switch
+        {
+            byte[] value   => value.Select(x => x / 255f).ToArray(),
+            _              => throw new ArgumentOutOfRangeException($"Invalid float[] input {data}"),
+        };
 }
+

--- a/Penumbra/Import/Models/Import/MeshImporter.cs
+++ b/Penumbra/Import/Models/Import/MeshImporter.cs
@@ -196,7 +196,9 @@ public class MeshImporter(IEnumerable<Node> nodes, IoNotifier notifier)
             // Per glTF specification, an asset with a skin MUST contain skinning attributes on its meshes.
             var joints0Accessor = primitive.GetVertexAccessor("JOINTS_0")?.AsVector4Array();
             var weights0Accessor = primitive.GetVertexAccessor("WEIGHTS_0")?.AsVector4Array();
-
+            var joints1Accessor  = primitive.GetVertexAccessor("JOINTS_1")?.AsVector4Array();
+            var weights1Accessor = primitive.GetVertexAccessor("WEIGHTS_1")?.AsVector4Array();
+            
             if (joints0Accessor == null || weights0Accessor == null)
                 throw notifier.Exception($"Primitive {primitiveIndex} is skinned but does not contain skinning vertex attributes.");
 
@@ -205,6 +207,8 @@ public class MeshImporter(IEnumerable<Node> nodes, IoNotifier notifier)
             {
                 var joints = joints0Accessor[i];
                 var weights = weights0Accessor[i];
+                var joints1 = joints1Accessor?[i];
+                var weights1 = weights1Accessor?[i];
                 for (var index = 0; index < 4; index++)
                 {
                     // If a joint has absolutely no weight, we omit the bone entirely.
@@ -212,26 +216,11 @@ public class MeshImporter(IEnumerable<Node> nodes, IoNotifier notifier)
                         continue;
 
                     usedJoints.Add((ushort)joints[index]);
-                }
-            }
-            
-            var joints1Accessor = primitive.GetVertexAccessor("JOINTS_1")?.AsVector4Array();
-            var weights1Accessor = primitive.GetVertexAccessor("WEIGHTS_1")?.AsVector4Array();
-            
-            if (joints1Accessor == null || weights1Accessor == null)
-                continue;
-
-            for (var i = 0; i < joints1Accessor.Count; i++)
-            {
-                var joints = joints1Accessor[i];
-                var weights = weights1Accessor[i];
-                for (var index = 0; index < 4; index++)
-                {
-                    // If a joint has absolutely no weight, we omit the bone entirely.
-                    if (weights[index] == 0)
-                        continue;
-
-                    usedJoints.Add((ushort)joints[index]);
+                        
+                    if (joints1 != null && weights1 != null && weights1.Value[index] != 0)
+                    {
+                        usedJoints.Add((ushort)joints1.Value[index]);
+                    }
                 }
             }
         }

--- a/Penumbra/Import/Models/Import/MeshImporter.cs
+++ b/Penumbra/Import/Models/Import/MeshImporter.cs
@@ -205,17 +205,18 @@ public class MeshImporter(IEnumerable<Node> nodes, IoNotifier notifier)
             // Build a set of joints that are referenced by this mesh.
             for (var i = 0; i < joints0Accessor.Count; i++) 
             {
-                var joints = joints0Accessor[i];
-                var weights = weights0Accessor[i];
+                var joints0 = joints0Accessor[i];
+                var weights0 = weights0Accessor[i];
                 var joints1 = joints1Accessor?[i];
                 var weights1 = weights1Accessor?[i];
                 for (var index = 0; index < 4; index++)
                 {
                     // If a joint has absolutely no weight, we omit the bone entirely.
-                    if (weights[index] == 0)
-                        continue;
+                    if (weights0[index] != 0)
+                    {
+                        usedJoints.Add((ushort)joints0[index]);
+                    }
 
-                    usedJoints.Add((ushort)joints[index]);
                         
                     if (joints1 != null && weights1 != null && weights1.Value[index] != 0)
                     {

--- a/Penumbra/Import/Models/Import/MeshImporter.cs
+++ b/Penumbra/Import/Models/Import/MeshImporter.cs
@@ -194,17 +194,37 @@ public class MeshImporter(IEnumerable<Node> nodes, IoNotifier notifier)
         foreach (var (primitive, primitiveIndex) in node.Mesh.Primitives.WithIndex())
         {
             // Per glTF specification, an asset with a skin MUST contain skinning attributes on its meshes.
-            var jointsAccessor = primitive.GetVertexAccessor("JOINTS_0")?.AsVector4Array();
-            var weightsAccessor = primitive.GetVertexAccessor("WEIGHTS_0")?.AsVector4Array();
+            var joints0Accessor = primitive.GetVertexAccessor("JOINTS_0")?.AsVector4Array();
+            var weights0Accessor = primitive.GetVertexAccessor("WEIGHTS_0")?.AsVector4Array();
 
-            if (jointsAccessor == null || weightsAccessor == null)
+            if (joints0Accessor == null || weights0Accessor == null)
                 throw notifier.Exception($"Primitive {primitiveIndex} is skinned but does not contain skinning vertex attributes.");
 
             // Build a set of joints that are referenced by this mesh.
-            for (var i = 0; i < jointsAccessor.Count; i++) 
+            for (var i = 0; i < joints0Accessor.Count; i++) 
             {
-                var joints = jointsAccessor[i];
-                var weights = weightsAccessor[i];
+                var joints = joints0Accessor[i];
+                var weights = weights0Accessor[i];
+                for (var index = 0; index < 4; index++)
+                {
+                    // If a joint has absolutely no weight, we omit the bone entirely.
+                    if (weights[index] == 0)
+                        continue;
+
+                    usedJoints.Add((ushort)joints[index]);
+                }
+            }
+            
+            var joints1Accessor = primitive.GetVertexAccessor("JOINTS_1")?.AsVector4Array();
+            var weights1Accessor = primitive.GetVertexAccessor("WEIGHTS_1")?.AsVector4Array();
+            
+            if (joints1Accessor == null || weights1Accessor == null)
+                continue;
+
+            for (var i = 0; i < joints1Accessor.Count; i++)
+            {
+                var joints = joints1Accessor[i];
+                var weights = weights1Accessor[i];
                 for (var index = 0; index < 4; index++)
                 {
                     // If a joint has absolutely no weight, we omit the bone entirely.

--- a/Penumbra/Import/Models/Import/VertexAttribute.cs
+++ b/Penumbra/Import/Models/Import/VertexAttribute.cs
@@ -168,9 +168,9 @@ public class VertexAttribute
             var closestIndex = Enumerable.Range(0, byteValues.Length)
                 .Where(i => adjustment switch
                 {
-                    < 0 when byteValues[i] > 0   => true,
-                    > 0 when byteValues[i] < 255 => true,
-                    _                            => true,
+                    < 0 => byteValues[i] > 0,
+                    > 0 => byteValues[i] < 255,
+                    _ => true,
                 })
                 .Select(index => (index, delta: Math.Abs(originalData[index] - (byteValues[index] * (1f / 255f)))))
                 .MinBy(x => x.delta)

--- a/Penumbra/Import/Models/Import/VertexAttribute.cs
+++ b/Penumbra/Import/Models/Import/VertexAttribute.cs
@@ -154,28 +154,6 @@ public class VertexAttribute
                 return AdjustByteArray(byteValues, originalData);
             }
         );
-       
-        /*var element = new MdlStructs.VertexElement()
-        {
-            Stream = 0,
-            Type   = (byte)MdlFile.VertexType.NByte4,
-            Usage  = (byte)MdlFile.VertexUsage.BlendWeights,
-        };
-
-        var weights0 = weights0Accessor.AsVector4Array();
-
-        return new VertexAttribute(
-            element,
-            index =>
-            {
-                var weight0 = weights0[index];
-                var originalData   = new[] { weight0.X, weight0.Y, weight0.Z, weight0.W };
-                var byteValues     = originalData.Select(x => (byte)Math.Round(x * 255f)).ToArray();
-                var newByteValues = AdjustByteArray(byteValues, originalData);
-                if (!newByteValues.SequenceEqual(byteValues))
-                    notifier.Warning("Adjusted blend weights to maintain precision.");
-                return newByteValues;
-            });*/
     }
 
     private static byte[] AdjustByteArray(byte[] byteValues, float[] originalValues)
@@ -268,28 +246,6 @@ public class VertexAttribute
                 return byteValues.Select(x => (byte)x).ToArray();
             }
         );
-        
-        /*var element = new MdlStructs.VertexElement()
-        {
-            Stream = 0,
-            Type   = (byte)MdlFile.VertexType.UByte4,
-            Usage  = (byte)MdlFile.VertexUsage.BlendIndices,
-        };
-
-        return new VertexAttribute(
-            element,
-            index =>
-            {
-                var gltfIndices = joints0[index];
-                var gltfWeights = weights0[index];
-                return BuildUByte4(new Vector4(
-                    gltfWeights.X == 0 ? 0 : boneMap[(ushort)gltfIndices.X],
-                    gltfWeights.Y == 0 ? 0 : boneMap[(ushort)gltfIndices.Y],
-                    gltfWeights.Z == 0 ? 0 : boneMap[(ushort)gltfIndices.Z],
-                    gltfWeights.W == 0 ? 0 : boneMap[(ushort)gltfIndices.W]
-                ));
-            }
-        );*/
     }
 
     public static VertexAttribute? Normal(Accessors accessors, IEnumerable<Accessors> morphAccessors)

--- a/Penumbra/Import/Models/Import/VertexAttribute.cs
+++ b/Penumbra/Import/Models/Import/VertexAttribute.cs
@@ -40,6 +40,7 @@ public class VertexAttribute
             MdlFile.VertexType.NByte4  => 4,
             MdlFile.VertexType.Half2   => 4,
             MdlFile.VertexType.Half4   => 8,
+            MdlFile.VertexType.UShort4 => 8,
 
             _ => throw new Exception($"Unhandled vertex type {(MdlFile.VertexType)Element.Type}"),
         };
@@ -121,89 +122,219 @@ public class VertexAttribute
 
     public static VertexAttribute? BlendWeight(Accessors accessors, IoNotifier notifier)
     {
-        if (!accessors.TryGetValue("WEIGHTS_0", out var accessor))
+        if (!accessors.TryGetValue("WEIGHTS_0", out var weights0Accessor))
             return null;
 
         if (!accessors.ContainsKey("JOINTS_0"))
             throw notifier.Exception("Mesh contained WEIGHTS_0 attribute but no corresponding JOINTS_0 attribute.");
 
-        var element = new MdlStructs.VertexElement()
+        if (accessors.TryGetValue("WEIGHTS_1", out var weights1Accessor))
         {
-            Stream = 0,
-            Type   = (byte)MdlFile.VertexType.NByte4,
-            Usage  = (byte)MdlFile.VertexUsage.BlendWeights,
-        };
+            if (!accessors.ContainsKey("JOINTS_1"))
+                throw notifier.Exception("Mesh contained WEIGHTS_1 attribute but no corresponding JOINTS_1 attribute.");
+            
+            var element = new MdlStructs.VertexElement()
+            {
+                Stream = 0,
+                Type  = (byte)MdlFile.VertexType.UShort4,
+                Usage = (byte)MdlFile.VertexUsage.BlendWeights,
+            };
 
-        var values = accessor.AsVector4Array();
+            var weights0 = weights0Accessor.AsVector4Array();
+            var weights1 = weights1Accessor.AsVector4Array();
 
-        return new VertexAttribute(
-            element,
-            index => {
-                // Blend weights are _very_ sensitive to float imprecision - a vertex sum being off
-                // by one, such as 256, is enough to cause a visible defect. To avoid this, we tweak
-                // the converted values to have the expected sum, preferencing values with minimal differences.
-                var originalValues = values[index];
-                var byteValues = BuildNByte4(originalValues);
-
-                var adjustment = 255 - byteValues.Select(value => (int)value).Sum();
-                while (adjustment != 0)
-                {
-                    var convertedValues = byteValues.Select(value => value * (1f / 255f)).ToArray();
-                    var closestIndex = Enumerable.Range(0, 4)
-                        .Where(index => {
-                            var byteValue = byteValues[index];
-                            if (adjustment < 0) return byteValue > 0;
-                            if (adjustment > 0) return byteValue < 255;
-                            return true;
-                        })
-                        .Select(index => (index, delta: Math.Abs(originalValues[index] - convertedValues[index])))
-                        .MinBy(x => x.delta)
-                        .index;
-                    byteValues[closestIndex] = (byte)(byteValues[closestIndex] + Math.CopySign(1, adjustment));
-                    adjustment = 255 - byteValues.Select(value => (int)value).Sum();
+            return new VertexAttribute(
+                element,
+                index => {
+                    var weight0       = weights0[index];
+                    var weight1       = weights1[index];
+                    var originalData  = BuildUshort4(weight0, weight1);
+                    var byteValues    = originalData.Select(x => (byte)Math.Round(x * 255f)).ToArray();
+                    return AdjustByteArray(byteValues, originalData);
                 }
-                
-                return byteValues;
-            }
-        );
+            );
+        }
+        else
+        {
+            var element = new MdlStructs.VertexElement()
+            {
+                Stream = 0,
+                Type   = (byte)MdlFile.VertexType.UShort4,
+                Usage  = (byte)MdlFile.VertexUsage.BlendWeights,
+            };
+
+            var weights0 = weights0Accessor.AsVector4Array();
+
+            return new VertexAttribute(
+                element,
+                index => {
+                    var weight0       = weights0[index];
+                    var weight1       = Vector4.Zero;
+                    var originalData  = BuildUshort4(weight0, weight1);
+                    var byteValues    = originalData.Select(x => (byte)Math.Round(x * 255f)).ToArray();
+                    return AdjustByteArray(byteValues, originalData);
+                }
+            );
+            
+            /*var element = new MdlStructs.VertexElement()
+            {
+                Stream = 0,
+                Type   = (byte)MdlFile.VertexType.NByte4,
+                Usage  = (byte)MdlFile.VertexUsage.BlendWeights,
+            };
+
+            var weights0 = weights0Accessor.AsVector4Array();
+
+            return new VertexAttribute(
+                element,
+                index =>
+                {
+                    var weight0 = weights0[index];
+                    var originalData   = new[] { weight0.X, weight0.Y, weight0.Z, weight0.W };
+                    var byteValues     = originalData.Select(x => (byte)Math.Round(x * 255f)).ToArray();
+                    var newByteValues = AdjustByteArray(byteValues, originalData);
+                    if (!newByteValues.SequenceEqual(byteValues))
+                        notifier.Warning("Adjusted blend weights to maintain precision.");
+                    return newByteValues;
+                });*/
+        }
+    }
+
+    private static byte[] AdjustByteArray(byte[] byteValues, float[] originalValues)
+    {
+        // Blend weights are _very_ sensitive to float imprecision - a vertex sum being off
+        // by one, such as 256, is enough to cause a visible defect. To avoid this, we tweak
+        // the converted values to have the expected sum, preferencing values with minimal differences.
+        var adjustment = 255 - byteValues.Select(value => (int)value).Sum();
+        while (adjustment != 0)
+        {
+            var convertedValues = byteValues.Select(value => value * (1f / 255f)).ToArray();
+            var closestIndex = Enumerable.Range(0, byteValues.Length)
+                .Where(index =>
+                {
+                    var byteValue = byteValues[index];
+                    if (adjustment < 0)
+                        return byteValue > 0;
+                    if (adjustment > 0)
+                        return byteValue < 255;
+
+                    return true;
+                })
+                .Select(index => (index, delta: Math.Abs(originalValues[index] - convertedValues[index])))
+                .MinBy(x => x.delta)
+                .index;
+            byteValues[closestIndex] = (byte)(byteValues[closestIndex] + Math.CopySign(1, adjustment));
+            adjustment               = 255 - byteValues.Select(value => (int)value).Sum();
+        }
+
+        return byteValues;
     }
 
     public static VertexAttribute? BlendIndex(Accessors accessors, IDictionary<ushort, ushort>? boneMap, IoNotifier notifier)
     {
-        if (!accessors.TryGetValue("JOINTS_0", out var jointsAccessor))
+        if (!accessors.TryGetValue("JOINTS_0", out var joints0Accessor))
             return null;
 
-        if (!accessors.TryGetValue("WEIGHTS_0", out var weightsAccessor))
+        if (!accessors.TryGetValue("WEIGHTS_0", out var weights0Accessor))
             throw notifier.Exception("Mesh contained JOINTS_0 attribute but no corresponding WEIGHTS_0 attribute.");
 
         if (boneMap == null)
             throw notifier.Exception("Mesh contained JOINTS_0 attribute but no bone mapping was created.");
 
-        var element = new MdlStructs.VertexElement()
+        var joints0  = joints0Accessor.AsVector4Array();
+        var weights0 = weights0Accessor.AsVector4Array();
+
+        if (accessors.TryGetValue("JOINTS_1", out var joints1Accessor))
         {
-            Stream = 0,
-            Type   = (byte)MdlFile.VertexType.UByte4,
-            Usage  = (byte)MdlFile.VertexUsage.BlendIndices,
-        };
+            if (!accessors.TryGetValue("WEIGHTS_1", out var weights1Accessor))
+                throw notifier.Exception("Mesh contained JOINTS_1 attribute but no corresponding WEIGHTS_1 attribute.");
 
-        var joints = jointsAccessor.AsVector4Array();
-        var weights = weightsAccessor.AsVector4Array();
-
-        return new VertexAttribute(
-            element,
-            index =>
+            var element = new MdlStructs.VertexElement
             {
-                var gltfIndices = joints[index];
-                var gltfWeights = weights[index]; 
+                Stream = 0,
+                Type   = (byte)MdlFile.VertexType.UShort4,
+                Usage  = (byte)MdlFile.VertexUsage.BlendIndices,
+            };
 
-                return BuildUByte4(new Vector4(
-                    gltfWeights.X == 0 ? 0 : boneMap[(ushort)gltfIndices.X],
-                    gltfWeights.Y == 0 ? 0 : boneMap[(ushort)gltfIndices.Y],
-                    gltfWeights.Z == 0 ? 0 : boneMap[(ushort)gltfIndices.Z],
-                    gltfWeights.W == 0 ? 0 : boneMap[(ushort)gltfIndices.W]
-                ));
-            }
-        );
+            var joints1  = joints1Accessor.AsVector4Array();
+            var weights1 = weights1Accessor.AsVector4Array();
+
+            return new VertexAttribute(
+                element,
+                index =>
+                {
+                    var gltfIndices0 = joints0[index];
+                    var gltfWeights0 = weights0[index];
+                    var gltfIndices1 = joints1[index];
+                    var gltfWeights1 = weights1[index];
+                    var v0 = new Vector4(
+                        gltfWeights0.X == 0 ? 0 : boneMap[(ushort)gltfIndices0.X],
+                        gltfWeights0.Y == 0 ? 0 : boneMap[(ushort)gltfIndices0.Y],
+                        gltfWeights0.Z == 0 ? 0 : boneMap[(ushort)gltfIndices0.Z],
+                        gltfWeights0.W == 0 ? 0 : boneMap[(ushort)gltfIndices0.W]
+                    );
+                    var v1 = new Vector4(
+                        gltfWeights1.X == 0 ? 0 : boneMap[(ushort)gltfIndices1.X],
+                        gltfWeights1.Y == 0 ? 0 : boneMap[(ushort)gltfIndices1.Y],
+                        gltfWeights1.Z == 0 ? 0 : boneMap[(ushort)gltfIndices1.Z],
+                        gltfWeights1.W == 0 ? 0 : boneMap[(ushort)gltfIndices1.W]
+                    );
+
+                    var byteValues = BuildUshort4(v0, v1);
+
+                    return byteValues.Select(x => (byte)x).ToArray();
+                }
+            );
+        }
+        else
+        {
+            var element = new MdlStructs.VertexElement
+            {
+                Stream = 0,
+                Type   = (byte)MdlFile.VertexType.UShort4,
+                Usage  = (byte)MdlFile.VertexUsage.BlendIndices,
+            };
+            
+            return new VertexAttribute(
+                element,
+                index =>
+                {
+                    var gltfIndices0 = joints0[index];
+                    var gltfWeights0 = weights0[index];
+                    var v0 = new Vector4(
+                        gltfWeights0.X == 0 ? 0 : boneMap[(ushort)gltfIndices0.X],
+                        gltfWeights0.Y == 0 ? 0 : boneMap[(ushort)gltfIndices0.Y],
+                        gltfWeights0.Z == 0 ? 0 : boneMap[(ushort)gltfIndices0.Z],
+                        gltfWeights0.W == 0 ? 0 : boneMap[(ushort)gltfIndices0.W]
+                    );
+                    var v1 = Vector4.Zero;
+                    var byteValues = BuildUshort4(v0, v1);
+
+                    return byteValues.Select(x => (byte)x).ToArray();
+                }
+            );
+            /*var element = new MdlStructs.VertexElement()
+            {
+                Stream = 0,
+                Type   = (byte)MdlFile.VertexType.UByte4,
+                Usage  = (byte)MdlFile.VertexUsage.BlendIndices,
+            };
+
+            return new VertexAttribute(
+                element,
+                index =>
+                {
+                    var gltfIndices = joints0[index];
+                    var gltfWeights = weights0[index];
+                    return BuildUByte4(new Vector4(
+                        gltfWeights.X == 0 ? 0 : boneMap[(ushort)gltfIndices.X],
+                        gltfWeights.Y == 0 ? 0 : boneMap[(ushort)gltfIndices.Y],
+                        gltfWeights.Z == 0 ? 0 : boneMap[(ushort)gltfIndices.Z],
+                        gltfWeights.W == 0 ? 0 : boneMap[(ushort)gltfIndices.W]
+                    ));
+                }
+            );*/
+        }
     }
 
     public static VertexAttribute? Normal(Accessors accessors, IEnumerable<Accessors> morphAccessors)
@@ -232,7 +363,7 @@ public class VertexAttribute
                 var value = values[vertexIndex];
 
                 var delta = morphValues[morphIndex]?[vertexIndex];
-                if (delta != null)
+                if (delta != null) 
                     value += delta.Value;
 
                 return BuildSingle3(value);
@@ -489,4 +620,18 @@ public class VertexAttribute
             (byte)Math.Round(input.Z * 255f),
             (byte)Math.Round(input.W * 255f),
         ];
+
+    private static float[] BuildUshort4(Vector4 v0, Vector4 v1)
+    {
+        var buf = new float[8];
+        buf[0] = v0.X;
+        buf[4] = v1.X;
+        buf[1] = v0.Y;
+        buf[5] = v1.Y;
+        buf[2] = v0.Z;
+        buf[6] = v1.Z;
+        buf[3] = v0.W;
+        buf[7] = v1.W;
+        return buf;
+    }
 }


### PR DESCRIPTION
Updates to export UShort4 blendweights/indices as VertexJoints8 and import models with JOINTS_1/WEIGHTS_1 defined

![image](https://github.com/user-attachments/assets/ed3acf98-696c-4462-9bb6-45c9c1ee80c3)
Blender recommended export change
Data->Skinning->Bone Influences: Include All Bone Influences (or set amount to 8)

Current Caveats:
- All weights/indices will be imported as UShort4, if it was exported in a different format the remaining 4 values will be set to 0
- Material computation isn't done so exported models won't look correct in blender if viewed with viewport shading
- I wrote most of this with no sleep, please verify first, especially re-import of weights/indices
