### PR TITLE
Adjust Bone/Material reading and allow for adding past 4 Materials.

### DIFF
--- a/Penumbra/Import/Models/Import/ModelImporter.cs
+++ b/Penumbra/Import/Models/Import/ModelImporter.cs
@@ -208,10 +208,10 @@ public partial class ModelImporter(ModelRoot model, IoNotifier notifier)
         if (index >= 0)
             return (ushort)index;
 
-        // If there's already 4 materials, we can't add any more.
+        // If there's already 10 materials, we can't add any more.
         // TODO: permit, with a warning to reduce, and validation in MdlTab.
         var count = _materials.Count;
-        if (count >= 4)
+        if (count >= 10)
             return 0;
 
         _materials.Add(materialName);
@@ -234,10 +234,10 @@ public partial class ModelImporter(ModelRoot model, IoNotifier notifier)
             boneIndices.Add((ushort)boneIndex);
         }
 
-        if (boneIndices.Count > 64)
-            throw notifier.Exception("XIV does not support meshes weighted to a total of more than 64 bones.");
+        if (boneIndices.Count > 128)
+            throw notifier.Exception("XIV does not support meshes weighted to a total of more than 128 bones.");
 
-        var boneIndicesArray = new ushort[64];
+        var boneIndicesArray = new ushort[128];
         Array.Copy(boneIndices.ToArray(), boneIndicesArray, boneIndices.Count);
 
         var boneTableIndex = _boneTables.Count;

--- a/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
+++ b/Penumbra/UI/AdvancedWindow/ModEditWindow.Models.cs
@@ -16,7 +16,7 @@ namespace Penumbra.UI.AdvancedWindow;
 
 public partial class ModEditWindow
 {
-    private const int MdlMaterialMaximum = 4;
+    private const int MdlMaterialMaximum = 10;
 
     private const string MdlImportDocumentation =
         @"https://github.com/xivdev/Penumbra/wiki/Model-IO#user-content-9b49d296-23ab-410a-845b-a3be769b71ea";


### PR DESCRIPTION
Small adjustment for new DT spec. Penumbra could already handle reading past 4 materials but UI had limited adding Materials in the Model tab to a max of 4. Similarly bone limits were adjusted from 64 > 128 accordingly.