### PR TITLE
More material editor fixes

### DIFF
--- a/Penumbra/Interop/Processing/ShpkPathPreProcessor.cs
+++ b/Penumbra/Interop/Processing/ShpkPathPreProcessor.cs
@@ -49,7 +49,7 @@ public sealed class ShpkPathPreProcessor(ResourceManagerService resourceManager,
         return null;
     }
 
-    private static SanityCheckResult SanityCheck(string path)
+    internal static SanityCheckResult SanityCheck(string path)
     {
         try
         {
@@ -79,7 +79,7 @@ public sealed class ShpkPathPreProcessor(ResourceManagerService resourceManager,
             _                          => string.Empty,
         };
 
-    private enum SanityCheckResult
+    internal enum SanityCheckResult
     {
         Success,
         IoError,

--- a/Penumbra/UI/AdvancedWindow/Materials/MtrlTab.ShaderPackage.cs
+++ b/Penumbra/UI/AdvancedWindow/Materials/MtrlTab.ShaderPackage.cs
@@ -10,6 +10,7 @@ using Penumbra.GameData;
 using Penumbra.GameData.Data;
 using Penumbra.GameData.Files;
 using Penumbra.GameData.Files.ShaderStructs;
+using Penumbra.Interop.Processing;
 using Penumbra.String.Classes;
 using static Penumbra.GameData.Files.ShpkFile;
 
@@ -128,7 +129,11 @@ public partial class MtrlTab
         if (!Utf8GamePath.FromString(defaultPath, out defaultGamePath))
             return FullPath.Empty;
 
-        return _edit.FindBestMatch(defaultGamePath);
+        var path = _edit.FindBestMatch(defaultGamePath);
+        if (!path.IsRooted || ShpkPathPreProcessor.SanityCheck(path.FullName) == ShpkPathPreProcessor.SanityCheckResult.Success)
+            return path;
+
+        return new FullPath(defaultPath);
     }
 
     private void LoadShpk(FullPath path)

--- a/Penumbra/UI/AdvancedWindow/Materials/MtrlTab.Textures.cs
+++ b/Penumbra/UI/AdvancedWindow/Materials/MtrlTab.Textures.cs
@@ -59,7 +59,7 @@ public partial class MtrlTab
             foreach (var textureId in TextureIds)
             {
                 var shpkTexture = _associatedShpk.GetTextureById(textureId);
-                if (shpkTexture is not { Slot: 2 })
+                if (shpkTexture is not { Slot: 2 } && (shpkTexture is not null || textureId == TableSamplerId))
                     continue;
 
                 var dkData     = TryGetShpkDevkitData<DevkitSampler>("Samplers", textureId, true);


### PR DESCRIPTION
This fixes two logic errors, the combination of which resulted in Mtrl file corruption when having severely outdated (pre-7.0 probably) ShPk mods.