### PR TITLE
Fix basecolor texture in material export

### DIFF
--- a/Penumbra/Import/Models/Export/MaterialExporter.cs
+++ b/Penumbra/Import/Models/Export/MaterialExporter.cs
@@ -1,6 +1,7 @@
 using Lumina.Data.Parsing;
 using Penumbra.GameData.Files;
 using Penumbra.GameData.Files.MaterialStructs;
+using Penumbra.UI.AdvancedWindow.Materials;
 using SharpGLTF.Materials;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Advanced;
@@ -140,13 +141,13 @@ public class MaterialExporter
 
                 // Lerp between table row values to fetch final pixel values for each subtexture.
                 var lerpedDiffuse = Vector3.Lerp((Vector3)prevRow.DiffuseColor, (Vector3)nextRow.DiffuseColor, rowBlend);
-                baseColorSpan[x].FromVector4(new Vector4(lerpedDiffuse, 1));
+                baseColorSpan[x].FromVector4(new Vector4(MtrlTab.PseudoSqrtRgb(lerpedDiffuse), 1));
 
                 var lerpedSpecularColor = Vector3.Lerp((Vector3)prevRow.SpecularColor, (Vector3)nextRow.SpecularColor, rowBlend);
-                specularSpan[x].FromVector4(new Vector4(lerpedSpecularColor, 1));
+                specularSpan[x].FromVector4(new Vector4(MtrlTab.PseudoSqrtRgb(lerpedSpecularColor), 1));
 
                 var lerpedEmissive = Vector3.Lerp((Vector3)prevRow.EmissiveColor, (Vector3)nextRow.EmissiveColor, rowBlend);
-                emissiveSpan[x].FromVector4(new Vector4(lerpedEmissive, 1));
+                emissiveSpan[x].FromVector4(new Vector4(MtrlTab.PseudoSqrtRgb(lerpedEmissive), 1));
             }
         }
     }

--- a/Penumbra/UI/AdvancedWindow/Materials/MtrlTab.CommonColorTable.cs
+++ b/Penumbra/UI/AdvancedWindow/Materials/MtrlTab.CommonColorTable.cs
@@ -594,7 +594,7 @@ public partial class MtrlTab
     internal static float PseudoSqrtRgb(float x)
         => x < 0.0f ? -MathF.Sqrt(-x) : MathF.Sqrt(x);
 
-    internal static Vector3 PseudoSqrtRgb(Vector3 vec)
+    public static Vector3 PseudoSqrtRgb(Vector3 vec)
         => new(PseudoSqrtRgb(vec.X), PseudoSqrtRgb(vec.Y), PseudoSqrtRgb(vec.Z));
 
     internal static Vector4 PseudoSqrtRgb(Vector4 vec)


### PR DESCRIPTION
Penumbra would not correctly transform the colour space when creating the basecolor texture, leading to models that appeared far too dark in blender. This PR fixes the issue.

Comparison (previous, this pr, textools): (`chara/equipment/e6144/model/c1201e6144_top.mdl`)

<img width="1536" height="1024" alt="comparison" src="https://github.com/user-attachments/assets/2d27cbb0-4671-4932-bf7a-8209b84bf587" />

Ingame:

<img width="968" height="984" alt="image" src="https://github.com/user-attachments/assets/bda6a5b8-de50-464e-9d34-b6bd8677f73f" />

Judging by the flaps on the shoulders, I think penumbra's interpretation is more correct than that of TexTools.

TexTools also messes up the jewelry on the metal heart on the belt of this dress (on the bottom center-right of the texture), which penumbra doesn't :)