### PR TITLE
Add game integrity message to On-Screen

### DIFF
--- a/Penumbra/UI/AdvancedWindow/ResourceTreeViewerFactory.cs
+++ b/Penumbra/UI/AdvancedWindow/ResourceTreeViewerFactory.cs
@@ -1,3 +1,4 @@
+using Dalamud.Plugin.Services;
 using OtterGui.Services;
 using Penumbra.Interop.ResourceTree;
 using Penumbra.Services;
@@ -10,8 +11,9 @@ public class ResourceTreeViewerFactory(
     ChangedItemDrawer changedItemDrawer,
     IncognitoService incognito,
     CommunicatorService communicator,
-    PcpService pcpService) : IService
+    PcpService pcpService,
+    IDataManager gameData) : IService
 {
     public ResourceTreeViewer Create(int actionCapacity, Action onRefresh, Action<ResourceNode, Vector2> drawActions)
-        => new(config, treeFactory, changedItemDrawer, incognito, actionCapacity, onRefresh, drawActions, communicator, pcpService);
+        => new(config, treeFactory, changedItemDrawer, incognito, actionCapacity, onRefresh, drawActions, communicator, pcpService, gameData);
 }


### PR DESCRIPTION
<img width="907" height="349" alt="image" src="https://github.com/user-attachments/assets/ba1b60eb-825f-4052-83e5-2247a7366937" />

I've been suggested to also add instructions for users to read repair's warnings wrt ReShade and that kind of stuff - but given the current length of this warning, I'm not sure how to integrate that in a way that won't end up in a "Penumbra users can read and other hilarious jokes you can tell yourself - Volume 3" way.