### PR TITLE
Makes `CollectionStorage` thread safe for parallel initialization of collections by one or multiple IPC consumers without requring framework thread synchronization.

### DIFF
--- a/Penumbra/Collections/Manager/CollectionStorage.cs
+++ b/Penumbra/Collections/Manager/CollectionStorage.cs
@@ -89,8 +89,12 @@ public class CollectionStorage : IReadOnlyList<ModCollection>, IDisposable, ISer
     /// <remarks> Starts at 1 because the empty collection gets Zero. </remarks>
     public LocalCollectionId CurrentCollectionId => new(_currentCollectionIdValue);
     
-    private LocalCollectionId AllocateNextId () 
-        => new(Interlocked.Increment(ref _currentCollectionIdValue));
+    private LocalCollectionId AllocateNextId ()
+    {
+        var newLocalId = new LocalCollectionId(_currentCollectionIdValue);
+        Interlocked.Increment(ref _currentCollectionIdValue);
+        return newLocalId;
+    }
 
     /// <summary> Default enumeration skips the empty collection. </summary>
     public IEnumerator<ModCollection> GetEnumerator()

--- a/Penumbra/Collections/Manager/CollectionStorage.cs
+++ b/Penumbra/Collections/Manager/CollectionStorage.cs
@@ -89,7 +89,7 @@ public class CollectionStorage : IReadOnlyList<ModCollection>, IDisposable, ISer
     /// <remarks> Starts at 1 because the empty collection gets Zero. </remarks>
     public LocalCollectionId CurrentCollectionId => new(_currentCollectionIdValue);
     
-    private LocalCollectionId AllocateNextId ()
+    private LocalCollectionId AllocateNextId()
     {
         var newLocalId = new LocalCollectionId(_currentCollectionIdValue);
         Interlocked.Increment(ref _currentCollectionIdValue);

--- a/Penumbra/Collections/Manager/CollectionStorage.cs
+++ b/Penumbra/Collections/Manager/CollectionStorage.cs
@@ -201,22 +201,23 @@ public class CollectionStorage : IReadOnlyList<ModCollection>, IDisposable, ISer
     /// </summary>
     public bool RemoveCollection(ModCollection collection)
     {
-        if (collection.Identity.Index <= ModCollection.Empty.Identity.Index || collection.Identity.Index >= Count)
-        {
-            Penumbra.Messager.NotificationMessage("Can not remove the empty collection.", NotificationType.Error, false);
-            return false;
-        }
-
-        if (collection.Identity.Index == DefaultNamed.Identity.Index)
-        {
-            Penumbra.Messager.NotificationMessage("Can not remove the default collection.", NotificationType.Error, false);
-            return false;
-        }
-
-        Delete(collection);
-        _saveService.ImmediateDelete(new ModCollectionSave(_modStorage, collection));
         lock (_collectionsLock) 
         {
+            if (collection.Identity.Index <= ModCollection.Empty.Identity.Index || collection.Identity.Index >= Count)
+            {
+                Penumbra.Messager.NotificationMessage("Can not remove the empty collection.", NotificationType.Error, false);
+                return false;
+            }
+
+            if (collection.Identity.Index == DefaultNamed.Identity.Index)
+            {
+                Penumbra.Messager.NotificationMessage("Can not remove the default collection.", NotificationType.Error, false);
+                return false;
+            }
+
+            Delete(collection);
+            _saveService.ImmediateDelete(new ModCollectionSave(_modStorage, collection));
+
             _collections.RemoveAt(collection.Identity.Index);
             // Update indices.
             for (var i = collection.Identity.Index; i < _collections.Count; ++i)

--- a/Penumbra/Collections/Manager/CollectionStorage.cs
+++ b/Penumbra/Collections/Manager/CollectionStorage.cs
@@ -207,7 +207,7 @@ public class CollectionStorage : IReadOnlyList<ModCollection>, IDisposable, ISer
     {
         lock (_collectionsLock) 
         {
-            if (collection.Identity.Index <= ModCollection.Empty.Identity.Index || collection.Identity.Index >= Count)
+            if (collection.Identity.Index <= ModCollection.Empty.Identity.Index || collection.Identity.Index >= _collections.Count)
             {
                 Penumbra.Messager.NotificationMessage("Can not remove the empty collection.", NotificationType.Error, false);
                 return false;


### PR DESCRIPTION
## Summary

As of now, most collection operations require being called on the framework thread despite not needing access to game objects. 

However, It is only when assigning via `AssignTemporaryCollection()`, in which it accesses `(ObjectManager)objects[actorIndex]` when framework thread is needed.

By making the internal data structures thread-safe, we can move collection management operations off the framework thread when safe and in doing so avoiding framework thread bottlenecks and reduce hitches, while avoiding desynchronizations between multiple consumers.

## Changes
 - **`_collectionsByLocal`**: Changed to `ConcurrentDictionary` for lock free concurrent access
 - **`_collections`**: Added locking to protect concurrent modifications
 - **`CurrentCollectionId`**: Implemented atomic increment
 - **Discovery / Change handlers**:  Snapshot collections before iteration to prevent concurrent modification exceptions
 - **Collection Addition**: Extracted collection addition logic to into dedicated `Add()` for clarity.

This should make the following IPC methods safe for off-framework access:
 - `CreateTemporaryCollection()`
 - `DeleteTemporaryCollection()`

`AssignTemporaryCollection()` still needs framework access as it is the crucial step when a collection is associated with a game object.

## Misc
There was also a duplicate operation at line 189 in the original file, method `RemoveCollection()`: 
`_collectionsByLocal.Remove(collection.Identity.LocalId);`
at line 183 in the original file, `Delete(collection);` is called, which is simply 
```csharp
public void Delete(ModCollection collection)
        => _collectionsByLocal.Remove(collection.Identity.LocalId);
````
The call at line 189 looks like a duplicate, and this PR also removes said duplicate operation.