### PR TITLE
Fix texture slice out-of-bounds error

### DIFF
--- a/Penumbra/UI/AdvancedWindow/Materials/MaterialTemplatePickers.cs
+++ b/Penumbra/UI/AdvancedWindow/Materials/MaterialTemplatePickers.cs
@@ -136,7 +136,7 @@ public sealed unsafe class MaterialTemplatePickers : IUiService
                 continue;
 
             var texture = textureRHs[j].Value->CsHandle.Texture;
-            if (texture == null)
+            if (texture == null || sliceIndex >= texture->ArraySize)
                 continue;
 
             var handle = _textureArraySlicer.GetImGuiHandle(texture, sliceIndex);


### PR DESCRIPTION
I think I saw a report about that somewhere, but I can't remember where.