### PR TITLE
Catch SEH exceptions in the Cloud API wrapper

### DIFF
--- a/Penumbra/Interop/CloudApi.cs
+++ b/Penumbra/Interop/CloudApi.cs
@@ -25,6 +25,11 @@ public static unsafe partial class CloudApi
             Penumbra.Log.Debug($"{nameof(CfGetSyncRootInfoByPath)} threw EntryPointNotFoundException");
             return false;
         }
+        catch (SEHException e)
+        {
+            Penumbra.Log.Debug($"{nameof(CfGetSyncRootInfoByPath)} threw SEHException:\n{e}");
+            return false;
+        }
 
         Penumbra.Log.Debug($"{nameof(CfGetSyncRootInfoByPath)} returned HRESULT 0x{hr:X8}");
         if (hr < 0)


### PR DESCRIPTION
This is an attempt at fixing the issue Wine 11 users are getting.