### PR TITLE
Separate .tex and .atex in texture save dialog

### DIFF
--- a/Penumbra/UI/FileEditing/Textures/CombiningTextureEditor.Interface.cs
+++ b/Penumbra/UI/FileEditing/Textures/CombiningTextureEditor.Interface.cs
@@ -319,7 +319,7 @@ public partial class CombiningTextureEditor
     private void OpenSaveAsDialog(string defaultExtension)
     {
         var fileName = Path.GetFileNameWithoutExtension(_left.Path.Length > 0 ? _left.Path : _right.Path);
-        _fileDialog.OpenSavePicker("Save Texture as TEX, DDS, PNG or TGA...", "Textures{.png,.dds,.tex,.atex,.tga},.tex{.tex,.atex},.dds,.png,.tga", fileName,
+        _fileDialog.OpenSavePicker("Save Texture as TEX, DDS, PNG or TGA...", "Textures{.png,.dds,.tex,.atex,.tga},.tex,.atex,.dds,.png,.tga", fileName,
             defaultExtension,
             (a, b) =>
             {


### PR DESCRIPTION
This should fix the issue people recently had on testing with the "Save as TEX" button.