### PR TITLE
Fix expand/collapse carets on material textures

### DIFF
--- a/Penumbra/UI/FileEditing/Materials/MaterialEditor.Textures.cs
+++ b/Penumbra/UI/FileEditing/Materials/MaterialEditor.Textures.cs
@@ -122,7 +122,7 @@ public partial class MaterialEditor
             var       tmp      = Mtrl.Textures[textureI].Path;
             var       unfolded = UnfoldedTextures.Contains(samplerI);
             table.NextColumn();
-            if (ImEx.Icon.Button(unfolded ? LunaStyle.TreeExpandIcon : LunaStyle.TreeCollapseIcon,
+            if (ImEx.Icon.Button(unfolded ? LunaStyle.TreeCollapseIcon : LunaStyle.TreeExpandIcon,
                     "Settings for this texture and the associated sampler"u8))
             {
                 unfolded = !unfolded;


### PR DESCRIPTION
Huh…

<img width="118" height="219" alt="image" src="https://github.com/user-attachments/assets/af5984d8-2f74-4235-a84a-09399f18d033" />
