### PR TITLE
Improve handling of resource load errors

### DIFF
--- a/Penumbra/Interop/Hooks/HookSettings.cs
+++ b/Penumbra/Interop/Hooks/HookSettings.cs
@@ -79,6 +79,7 @@ public class HookOverrides
         public bool WeaponReload;
         public bool SetupPlayerNpc;
         public bool ConstructCutsceneCharacter;
+        public bool CharacterSetupSlotModel;
     }
 
     public struct PostProcessingHooks

--- a/Penumbra/Interop/Hooks/Objects/CharacterSetupSlotModel.cs
+++ b/Penumbra/Interop/Hooks/Objects/CharacterSetupSlotModel.cs
@@ -1,0 +1,46 @@
+using FFXIVClientStructs.FFXIV.Client.Graphics.Render;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
+using FFXIVClientStructs.Interop;
+using Luna;
+
+namespace Penumbra.Interop.Hooks.Objects;
+
+// TODO ClientStructs-ify (aers/FFXIVClientStructs#1805)
+public sealed unsafe class CharacterSetupSlotModel : FastHook<CharacterSetupSlotModel.Delegate>
+{
+    public CharacterSetupSlotModel(HookManager hooks)
+    {
+        Task = hooks.CreateHook<Delegate>("CharacterBase.SetupSlotModel", "89 54 24 ?? 55 56 41 56 48 81 EC", Detour,
+            !HookOverrides.Instance.Objects.CharacterSetupSlotModel);
+    }
+
+    public delegate nint Delegate(CharacterBase* pThis, uint slot);
+
+    public nint Detour(CharacterBase* pThis, uint slot)
+    {
+        var ret   = Task.Result!.Original.Invoke(pThis, slot);
+        var model = pThis->Models[slot];
+        if (model is not null)
+        {
+            var origialCount = model->MaterialCount;
+            var materials    = model->MaterialsSpan;
+            var actualCount  = materials.LastIndexOfAnyExcept(default(Pointer<Material>)) + 1;
+            if (actualCount < origialCount)
+            {
+                Penumbra.Log.Warning(
+                    $"Trimming materials of an instance of model {model->ModelResourceHandle->FileName}: {origialCount} materials are declared, but only {actualCount} were successfully loaded.");
+                model->MaterialCount = actualCount;
+
+                materials = materials[..actualCount];
+                if (MemoryExtensions.IndexOf(materials, default(Pointer<Material>)) >= 0)
+                {
+                    // This should never happen. Should it happen on certain slots, it will be a cause of crashes.
+                    Penumbra.Log.Fatal(
+                        $"Some materials of an instance of model {model->ModelResourceHandle->FileName} failed to load. This may cause further issues.");
+                }
+            }
+        }
+
+        return ret;
+    }
+}

--- a/Penumbra/UI/ResourceWatcher/ResourceWatcher.cs
+++ b/Penumbra/UI/ResourceWatcher/ResourceWatcher.cs
@@ -178,6 +178,8 @@ public sealed class ResourceWatcher : IDisposable, ITab<TabType>
 
     private unsafe void OnResourceLoaded(ResourceHandle* handle, Utf8GamePath path, FullPath? manipulatedPath, ResolveData data)
     {
+        LogIfFailed(handle, path, false);
+
         if (_config.ResourceLoggerWriteToLog)
         {
             var log   = Filter(path.Path, out var name);
@@ -208,6 +210,8 @@ public sealed class ResourceWatcher : IDisposable, ITab<TabType>
     {
         if (!isAsync)
             return;
+
+        LogIfFailed(resource, original, true);
 
         if (_config.ResourceLoggerWriteToLog && Filter(path, out var match))
             Penumbra.Log.Information(
@@ -273,6 +277,15 @@ public sealed class ResourceWatcher : IDisposable, ITab<TabType>
         }
 
         return $"0x{resolve.AssociatedGameObject:X}";
+    }
+
+    private static unsafe void LogIfFailed(ResourceHandle* resource, Utf8GamePath originalPath, bool isAsync)
+    {
+        if (resource is null || resource->UnkState is not 2 || resource->LoadState <= LoadState.Success)
+            return;
+
+        Penumbra.Log.Warning(
+            $"Failed to {(isAsync ? "asynchronously" : "synchronously")} load resource {resource->CsHandle.FileName}, original path: {originalPath}, state: {resource->UnkState}:{resource->LoadState}");
     }
 
     private void Enqueue(Record record)


### PR DESCRIPTION
This trims the material span of models when some material fails to load, in order to mitigate the recent crash, and also adds warnings to Dalamud's logs when this trimming happens, and in some other error cases.