### PR TITLE
Adjust .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,31 +1,10 @@
-# Standard properties
+[*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
+# Standard properties
 csharp_indent_labels = one_less_than_current
-csharp_prefer_simple_using_statement = true:suggestion
-csharp_prefer_braces = true:silent
-csharp_style_prefer_method_group_conversion = true:silent
-csharp_style_expression_bodied_methods = false:silent
-csharp_style_expression_bodied_constructors = false:silent
-csharp_style_expression_bodied_operators = false:silent
-csharp_style_expression_bodied_properties = true:silent
-csharp_style_expression_bodied_indexers = true:silent
-csharp_style_expression_bodied_accessors = true:silent
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_expression_bodied_local_functions = false:silent
-csharp_style_throw_expression = true:suggestion
-csharp_style_prefer_null_check_over_type_check = true:suggestion
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
-csharp_style_prefer_index_operator = true:suggestion
-csharp_style_prefer_range_operator = true:suggestion
-csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
-csharp_style_prefer_tuple_swap = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-csharp_style_prefer_top_level_statements = true:silent
-
-[*]
 # Microsoft .NET properties
 csharp_indent_braces=false
 csharp_indent_switch_labels=true


### PR DESCRIPTION
Adds `trim_trailing_whitespace = true` in an attempt to make that more systematic (it already happens in Rider within a block when erasing the closing `}` and putting it back, but should probably happen systematically on saving, I think?) ;

Moves `csharp_indent_labels = one_less_than_current` in the `[*]` section, [which is required per EC spec](https://spec.editorconfig.org/#supported-pairs):
> With the exception of the `root` key, all pairs MUST be located under a section to take effect.

Removes the rest of the settings that are out of `[*]` but also already present in the section.