### PR TITLE
Use Lumina lax material suffix validation in model export + minor improvements

### DIFF
--- a/Penumbra/Import/Models/ModelManager.cs
+++ b/Penumbra/Import/Models/ModelManager.cs
@@ -119,7 +119,7 @@ public sealed class ModelManager(
 
         // Get standardised paths
         var absolutePath = rawPath.StartsWith('/')
-            ? LuminaMaterial.ResolveRelativeMaterialPath(rawPath, variantId)
+            ? LuminaMaterial.ResolveRelativeMaterialPath(rawPath, variantId, false)
             : rawPath;
         var relativePath = rawPath.StartsWith('/')
             ? rawPath

--- a/Penumbra/UI/FileEditing/FileEditingContext.cs
+++ b/Penumbra/UI/FileEditing/FileEditingContext.cs
@@ -22,7 +22,7 @@ public abstract class FileEditingContext
     /// </summary>
     /// <remarks>
     /// Tries to resolve from the current collection first and chooses the currently resolved file if any exists.
-    /// If none exists, goes through all options in the currently selected mod (if any) in order of priority and resolves in them. 
+    /// If none exists, goes through all options in the currently selected mod (if any) in order of priority and resolves in them.
     /// If no redirection is found in either of those options, returns the original path.
     /// </remarks>
     public FullPath FindBestMatch(Utf8GamePath path)
@@ -67,6 +67,20 @@ public abstract class FileEditingContext
             }
 
         return ret;
+    }
+
+    public IEnumerable<IModDataContainer>? GetModDataContainers()
+    {
+        if (Mod is not { } mod)
+            return null;
+
+        if (Option is not { } option)
+            return mod.AllDataContainers;
+
+        // Filter then prepend the current option to ensure it's chosen first.
+        return mod.AllDataContainers
+            .Where(subMod => subMod != option)
+            .Prepend(option);
     }
 
     public abstract FileRegistry? TryFindFileRegistry(Mod mod, Utf8RelPath relPath);

--- a/Penumbra/UI/FileEditing/Models/ModelEditor.cs
+++ b/Penumbra/UI/FileEditing/Models/ModelEditor.cs
@@ -6,6 +6,7 @@ using Penumbra.GameData.Files;
 using Penumbra.Import.Models;
 using Penumbra.Import.Models.Export;
 using Penumbra.Meta.Manipulations;
+using Penumbra.Mods.SubMods;
 using Penumbra.String.Classes;
 using Penumbra.UI.Classes;
 
@@ -98,8 +99,8 @@ public sealed partial class ModelEditor : IFileEditor
         }
 
         // If there's no current mod (somehow), there's nothing to resolve the model within.
-        var mod = _context?.Mod;
-        if (mod == null)
+        var containers = _context?.GetModDataContainers();
+        if (containers is null)
             return;
 
         if (!Path.IsPathRooted(path) && Utf8GamePath.FromString(path, out var p))
@@ -114,7 +115,7 @@ public sealed partial class ModelEditor : IFileEditor
         {
             // TODO: Is it worth trying to order results based on option priorities for cases where more than one match is found?
             // NOTE: We're using case-insensitive comparisons, as option group paths in mods are stored in lower case, but the mod editor uses paths directly from the file system, which may be mixed case.
-            return mod.AllDataContainers
+            return containers
                 .SelectMany(m => m.Files.Concat(m.FileSwaps))
                 .Where(kv => kv.Value.FullName.Equals(path, StringComparison.OrdinalIgnoreCase))
                 .Select(kv => kv.Key)
@@ -149,15 +150,11 @@ public sealed partial class ModelEditor : IFileEditor
 
     private KeyValuePair<EstIdentifier, EstEntry>[] GetCurrentEstManipulations()
     {
-        var mod    = _context?.Mod;
-        var option = _context?.Option;
-        if (mod == null || option == null)
+        var containers = _context?.GetModDataContainers();
+        if (containers is null)
             return [];
 
-        // Filter then prepend the current option to ensure it's chosen first.
-        return mod.AllDataContainers
-            .Where(subMod => subMod != option)
-            .Prepend(option)
+        return containers
             .SelectMany(subMod => subMod.Manipulations.Est)
             .ToArray();
     }
@@ -316,14 +313,13 @@ public sealed partial class ModelEditor : IFileEditor
 
     /// <summary> Read a file from the active collection or game. </summary>
     /// <param name="path"> Game path to the file to load. </param>
-    // TODO: Also look up files within the current mod regardless of mod state?
     private byte[]? ReadFile(string path)
     {
         // TODO: if cross-collection lookups are turned off, this conversion can be skipped
         if (!Utf8GamePath.FromString(path, out var utf8Path))
             throw new Exception($"Resolved path {path} could not be converted to a game path.");
 
-        var resolvedPath = _activeCollections.Current.ResolvePath(utf8Path) ?? new FullPath(utf8Path);
+        var resolvedPath = _context?.FindBestMatch(utf8Path) ?? _activeCollections.Current.ResolvePath(utf8Path) ?? new FullPath(utf8Path);
 
         // TODO: is it worth trying to use streams for these instead? I'll need to do this for mtrl/tex too, so might be a good idea. that said, the mtrl reader doesn't accept streams, so...
         return resolvedPath.IsRooted
@@ -336,7 +332,7 @@ public sealed partial class ModelEditor : IFileEditor
     /// While materials can be relative (`/mt_...`) or absolute (`bg/...`),
     /// they invariably must contain at least one directory seperator.
     /// Missing this can lead to a crash.
-    /// 
+    ///
     /// They must also be at least one character (though this is enforced
     /// by containing a `/`), and end with `.mtrl`.
     /// </remarks>


### PR DESCRIPTION
- Use Lumina lax material suffix validation ;
- Always put the current option first when enumerating the current mod's containers for model stuff (and refactor that) ;
- Use `FindBestMatch` to use files from the current mod if the current collection has nothing for the requested path ;
- Whitespace our beloved…